### PR TITLE
Further speedup s3 glob

### DIFF
--- a/megfile/s3.py
+++ b/megfile/s3.py
@@ -1008,12 +1008,11 @@ def _s3_glob_stat_single_path(
                     path = s3_path_join(
                         's3://', bucket, common_prefix['Prefix'])
                     dirname = os.path.dirname(path)
-                    while dirname not in dirnames and dirname != top_dir:
+                    if dirname not in dirnames and dirname != top_dir:
                         dirnames.add(dirname)
                         path = dirname + '/' if search_dir else dirname
                         if pattern.match(path):
                             yield FileEntry(path, StatResult(isdir=True))
-                        dirname = os.path.dirname(dirname)
 
     return create_generator(s3_pathname)
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1721,6 +1721,25 @@ def test_s3_iglob(truncating_client):
         s3.s3_iglob('s3://')
 
 
+def test_group_s3path_by_bucket(truncating_client):
+    assert sorted(
+        s3._group_s3path_by_bucket(
+            r"s3://*ForGlobTest{1,2/a,2/1/a}/1.jso?,")) == [
+                's3://bucketForGlobTest2/{1/a,a}/1.jso?,'
+            ]
+
+    assert sorted(
+        s3._group_s3path_by_bucket(
+            r's3://{emptybucket,bucket}ForGlob{Test,Test2,Test3}/c/a/a')) == [
+                's3://bucketForGlobTest/c/a/a',
+                's3://bucketForGlobTest2/c/a/a',
+                's3://bucketForGlobTest3/c/a/a',
+                's3://emptybucketForGlobTest/c/a/a',
+                's3://emptybucketForGlobTest2/c/a/a',
+                's3://emptybucketForGlobTest3/c/a/a',
+            ]
+
+
 def test_s3_glob_stat(truncating_client, mocker):
     mocker.patch('megfile.s3.StatResult', side_effect=FakeStatResult)
 


### PR DESCRIPTION
Optimize the speed under such circumstance: only last part of path contains non-recursive wildcard characters.
And now only bucket with wildcard characters will be matched with all bucket names, which will help speedup slightly.