### PR TITLE
upload coverage to Codecov

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -49,3 +49,7 @@ jobs:
       - name: Run unit-test
         run: |
           make test
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true


### PR DESCRIPTION
So we can keep an eye on the code coverage. See also: https://docs.codecov.com/docs/quick-start