### PR TITLE
Fix/smart_move

### DIFF
--- a/megfile/fs.py
+++ b/megfile/fs.py
@@ -276,40 +276,34 @@ def fs_relpath(path: PathLike, start: Optional[str] = None) -> str:
     return FSPath(path).relpath(start)
 
 
-def fs_rename(
-        src_path: PathLike, dst_path: PathLike,
-        followlinks: bool = False) -> None:
+def fs_rename(src_path: PathLike, dst_path: PathLike) -> None:
     '''
     rename file on fs
 
     :param src_path: Given path
     :param dst_path: Given destination path
     '''
-    return FSPath(src_path).rename(dst_path, followlinks)
+    return FSPath(src_path).rename(dst_path)
 
 
-def fs_move(
-        src_path: PathLike, dst_path: PathLike,
-        followlinks: bool = False) -> None:
+def fs_move(src_path: PathLike, dst_path: PathLike) -> None:
     '''
     move file on fs
 
     :param src_path: Given path
     :param dst_path: Given destination path
     '''
-    return FSPath(src_path).replace(dst_path, followlinks)
+    return FSPath(src_path).replace(dst_path)
 
 
-def fs_remove(
-        path: PathLike, missing_ok: bool = False,
-        followlinks: bool = False) -> None:
+def fs_remove(path: PathLike, missing_ok: bool = False) -> None:
     '''
     Remove the file or directory on fs
 
     :param path: Given path
     :param missing_ok: if False and target file/directory not exists, raise FileNotFoundError
     '''
-    return FSPath(path).remove(missing_ok, followlinks)
+    return FSPath(path).remove(missing_ok)
 
 
 def fs_scan(path: PathLike, missing_ok: bool = True,

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -300,27 +300,23 @@ class FSPath(URIPath):
         '''
         return fspath(os.path.relpath(self.path_without_protocol, start=start))
 
-    def rename(self, dst_path: PathLike, followlinks: bool = False) -> None:
+    def rename(self, dst_path: PathLike) -> None:
         '''
         rename file on fs
 
         :param dst_path: Given destination path
         '''
-        if self.is_dir(followlinks=followlinks):
-            shutil.move(self.path_without_protocol, dst_path)
-        else:
-            os.rename(self.path_without_protocol, dst_path)
+        shutil.move(self.path_without_protocol, dst_path)
 
-    def replace(self, dst_path: PathLike, followlinks: bool = False) -> None:
+    def replace(self, dst_path: PathLike) -> None:
         '''
         move file on fs
 
         :param dst_path: Given destination path
         '''
-        return self.rename(dst_path=dst_path, followlinks=followlinks)
+        return self.rename(dst_path=dst_path)
 
-    def remove(
-            self, missing_ok: bool = False, followlinks: bool = False) -> None:
+    def remove(self, missing_ok: bool = False) -> None:
         '''
         Remove the file or directory on fs
 
@@ -328,7 +324,7 @@ class FSPath(URIPath):
         '''
         if missing_ok and not self.exists():
             return
-        if self.is_dir(followlinks=followlinks):
+        if self.is_dir():
             shutil.rmtree(self.path_without_protocol)
         else:
             os.remove(self.path_without_protocol)

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -1300,7 +1300,7 @@ class S3Path(URIPath):
                 self.path_with_protocol, dst_url):
             S3Path(src_file_path).rename(dst_file_path)
 
-    def remove(self, missing_ok: bool = False, **kwargs) -> None:
+    def remove(self, missing_ok: bool = False) -> None:
         '''
         Remove the file or directory on s3, `s3://` and `s3://bucket` are not permitted to remove
 

--- a/megfile/smart.py
+++ b/megfile/smart.py
@@ -351,9 +351,7 @@ def smart_sync(
             followlinks=followlinks)
 
 
-def smart_remove(
-        path: PathLike, missing_ok: bool = False,
-        followlinks: bool = False) -> None:
+def smart_remove(path: PathLike, missing_ok: bool = False) -> None:
     '''
     Remove the file or directory on s3 or fs, `s3://` and `s3://bucket` are not permitted to remove
 
@@ -361,7 +359,7 @@ def smart_remove(
     :param missing_ok: if False and target file/directory not exists, raise FileNotFoundError
     :raises: PermissionError, FileNotFoundError
     '''
-    SmartPath(path).remove(missing_ok=missing_ok, followlinks=followlinks)
+    SmartPath(path).remove(missing_ok=missing_ok)
 
 
 def smart_rename(
@@ -384,9 +382,7 @@ def smart_rename(
     smart_unlink(src_path)
 
 
-def smart_move(
-        src_path: PathLike, dst_path: PathLike,
-        followlinks: bool = False) -> None:
+def smart_move(src_path: PathLike, dst_path: PathLike) -> None:
     '''
     Move file/directory on s3 or fs. `s3://` or `s3://bucket` is not allowed to move
 
@@ -396,13 +392,10 @@ def smart_move(
     src_protocol, _ = SmartPath._extract_protocol(src_path)
     dst_protocol, _ = SmartPath._extract_protocol(dst_path)
     if src_protocol == dst_protocol:
-        if src_protocol == 'file':
-            SmartPath(src_path).rename(dst_path, followlinks=followlinks)
-        else:
-            SmartPath(src_path).rename(dst_path)
+        SmartPath(src_path).rename(dst_path)
         return
-    smart_sync(src_path, dst_path, followlinks=followlinks)
-    smart_remove(src_path, followlinks=followlinks)
+    smart_sync(src_path, dst_path, followlinks=True)
+    smart_remove(src_path)
 
 
 def smart_unlink(path: PathLike, missing_ok: bool = False) -> None:

--- a/megfile/smart.py
+++ b/megfile/smart.py
@@ -362,16 +362,14 @@ def smart_remove(path: PathLike, missing_ok: bool = False) -> None:
     SmartPath(path).remove(missing_ok=missing_ok)
 
 
-def smart_rename(
-        src_path: PathLike, dst_path: PathLike,
-        followlinks: bool = False) -> None:
+def smart_rename(src_path: PathLike, dst_path: PathLike) -> None:
     '''
     Move file on s3 or fs. `s3://` or `s3://bucket` is not allowed to move
 
     :param src_path: Given source path
     :param dst_path: Given destination path
     '''
-    if smart_isdir(src_path, followlinks=followlinks):
+    if smart_isdir(src_path):
         raise IsADirectoryError('%r is a directory' % PathLike)
     src_protocol, _ = SmartPath._extract_protocol(src_path)
     dst_protocol, _ = SmartPath._extract_protocol(dst_path)

--- a/megfile/smart.py
+++ b/megfile/smart.py
@@ -370,7 +370,7 @@ def smart_rename(src_path: PathLike, dst_path: PathLike) -> None:
     :param dst_path: Given destination path
     '''
     if smart_isdir(src_path):
-        raise IsADirectoryError('%r is a directory' % PathLike)
+        raise IsADirectoryError('%r is a directory' % src_path)
     src_protocol, _ = SmartPath._extract_protocol(src_path)
     dst_protocol, _ = SmartPath._extract_protocol(dst_path)
     if src_protocol == dst_protocol:

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -947,6 +947,34 @@ def test_fs_rename(filesystem):
     assert not os.path.exists(src)
 
 
+def test_fs_rename_file_in_diff_dir(filesystem):
+    os.makedirs('dir')
+    os.makedirs('dir2')
+    src = 'dir/file'
+    dst = 'dir2/file1'
+    with open(src, 'w') as f:
+        f.write("test")
+    assert os.path.exists(src)
+    fs.fs_rename(src, dst)
+    assert os.path.exists(dst)
+    assert not os.path.exists(src)
+
+
+def test_fs_rename_dir(filesystem):
+    src_dir = 'dir'
+    dst_dir = 'dir2'
+    file_name = 'file'
+    os.makedirs(src_dir)
+    src = os.path.join(src_dir, file_name)
+    with open(src, 'w') as f:
+        f.write("test")
+    assert os.path.exists(src)
+    fs.fs_rename(src_dir, dst_dir)
+    assert os.path.exists(dst_dir)
+    assert os.path.exists(os.path.join(dst_dir, file_name))
+    assert not os.path.exists(src_dir)
+
+
 def test_fs_rename_symlink(filesystem):
     '''
     /src/
@@ -989,7 +1017,7 @@ def test_fs_move_symlink(filesystem):
         f.write('')
     os.symlink('src', '/dst/link')
     fs.fs_exists('/dst/link', followlinks=True) is True
-    fs.fs_move('src', 'src_copy', followlinks=True)
+    fs.fs_move('src', 'src_copy')
     assert os.path.exists('src_copy')
     assert not os.path.exists('src')
     assert not os.path.exists('/dst/link')

--- a/tests/test_smart.py
+++ b/tests/test_smart.py
@@ -380,11 +380,11 @@ def test_smart_remove(funcA):
 def test_smart_remove(mocker):
     fs_remove = mocker.patch('megfile.fs_path.FSPath.remove')
     smart.smart_remove('/test')
-    fs_remove.assert_called_once_with(missing_ok=False, followlinks=False)
+    fs_remove.assert_called_once_with(missing_ok=False)
 
     s3_remove = mocker.patch('megfile.s3_path.S3Path.remove')
     smart.smart_remove('s3://test')
-    s3_remove.assert_called_once_with(missing_ok=False, followlinks=False)
+    s3_remove.assert_called_once_with(missing_ok=False)
 
 
 def test_smart_move(mocker):
@@ -402,8 +402,8 @@ def test_smart_move(mocker):
     func_smart_remove = mocker.patch('megfile.smart.smart_remove')
     smart.smart_move('/bucket/a', 's3://bucket/b')
     func_smart_sync.assert_called_once_with(
-        '/bucket/a', 's3://bucket/b', followlinks=False)
-    func_smart_remove.assert_called_once_with('/bucket/a', followlinks=False)
+        '/bucket/a', 's3://bucket/b', followlinks=True)
+    func_smart_remove.assert_called_once_with('/bucket/a')
 
 
 @patch.object(SmartPath, 'rename')


### PR DESCRIPTION
修复 rename 跨设备或者跨系统出错问题；
去掉了 rename，move，remove 的 followlinks，和标准库对其