### PR TITLE
feat: read endpoint_url from more config keys & env vars

### DIFF
--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -138,15 +138,19 @@ def get_endpoint_url(profile_name: Optional[str] = None) -> str:
 
     :returns: S3 endpoint url
     '''
-    environ_key = f'{profile_name}__OSS_ENDPOINT'.upper(
-    ) if profile_name else 'OSS_ENDPOINT'
-    environ_endpoint_url = os.environ.get(environ_key)
-    if environ_endpoint_url:
-        warning_endpoint_url(environ_key, environ_endpoint_url)
-        return environ_endpoint_url
+    if profile_name:
+        environ_keys = (f'{profile_name}__OSS_ENDPOINT'.upper(),)
+    else:
+        environ_keys = ('OSS_ENDPOINT', 'AWS_ENDPOINT_URL')
+    for environ_key in environ_keys:
+        environ_endpoint_url = os.environ.get(environ_key)
+        if environ_endpoint_url:
+            warning_endpoint_url(environ_key, environ_endpoint_url)
+            return environ_endpoint_url
     try:
-        config_endpoint_url = get_scoped_config(profile_name=profile_name).get(
-            's3', {}).get('endpoint_url')
+        config = get_scoped_config(profile_name=profile_name)
+        config_endpoint_url = config.get('s3', {}).get('endpoint_url')
+        config_endpoint_url = config_endpoint_url or config.get('endpoint_url')
         if config_endpoint_url:
             warning_endpoint_url('~/.aws/config', config_endpoint_url)
             return config_endpoint_url


### PR DESCRIPTION
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-endpoints.html#endpoints-precedence

按照 awscli / asyncbotocore 这两个库的约定，额外从环境变量 `AWS_ENDPOINT_URL` 和 配置文件 `endpoint_url`（之前是 `s3.endpoint_url`）读取 endpoint_url

读取的顺序保持不变，优先读取之前的环境变量和配置，以保持向前兼容