### PR TITLE
makesure block_offset is int

### DIFF
--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -144,7 +144,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
 
         self._offset = max(min(target_offset, self._content_size), 0)
         block_index = self._offset // self._block_size
-        block_offset = self._offset % self._block_size
+        block_offset = int(self._offset % self._block_size)
         self._seek_buffer(block_index, block_offset)
         return self._offset
 

--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -54,8 +54,9 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
                 'got: block_capacity=%s, block_forward=%s' %
                 (block_capacity, block_forward))
 
+        block_size = int(block_size)
         self._max_retries = max_retries
-        self._block_size = int(block_size)
+        self._block_size = block_size
         self._block_capacity = block_capacity  # Max number of blocks
         self._block_forward = block_forward  # Number of blocks every prefetch, which should be smaller than block_capacity
 
@@ -107,6 +108,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
 
     @_offset.setter
     def _offset(self, value: int):
+        value = int(value)
         if value > self._backoff_size:
             _logger.debug(
                 'reading file: %r, current offset / total size: %s / %s' % (
@@ -114,7 +116,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
                     get_human_size(self._content_size)))
         while value > self._backoff_size:
             self._backoff_size *= BACKOFF_FACTOR
-        self.__offset = int(value)
+        self.__offset = value
 
     def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
         '''Change stream position.
@@ -127,6 +129,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
 
         Returns the new absolute position.
         '''
+        offset = int(offset)
         if self.closed:
             raise IOError('file already closed: %r' % self.name)
         if whence == os.SEEK_CUR:
@@ -141,7 +144,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
         if target_offset == self._offset:
             return target_offset
 
-        self._offset = int(max(min(target_offset, self._content_size), 0))
+        self._offset = max(min(target_offset, self._content_size), 0)
         block_index = self._offset // self._block_size
         block_offset = self._offset % self._block_size
         self._seek_buffer(block_index, block_offset)

--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -55,7 +55,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
                 (block_capacity, block_forward))
 
         self._max_retries = max_retries
-        self._block_size = block_size
+        self._block_size = int(block_size)
         self._block_capacity = block_capacity  # Max number of blocks
         self._block_forward = block_forward  # Number of blocks every prefetch, which should be smaller than block_capacity
 
@@ -114,7 +114,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
                     get_human_size(self._content_size)))
         while value > self._backoff_size:
             self._backoff_size *= BACKOFF_FACTOR
-        self.__offset = value
+        self.__offset = int(value)
 
     def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
         '''Change stream position.
@@ -129,7 +129,6 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
         '''
         if self.closed:
             raise IOError('file already closed: %r' % self.name)
-
         if whence == os.SEEK_CUR:
             target_offset = self._offset + offset
         elif whence == os.SEEK_END:
@@ -142,9 +141,9 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
         if target_offset == self._offset:
             return target_offset
 
-        self._offset = max(min(target_offset, self._content_size), 0)
+        self._offset = int(max(min(target_offset, self._content_size), 0))
         block_index = self._offset // self._block_size
-        block_offset = int(self._offset % self._block_size)
+        block_offset = self._offset % self._block_size
         self._seek_buffer(block_index, block_offset)
         return self._offset
 

--- a/megfile/lib/combine_reader.py
+++ b/megfile/lib/combine_reader.py
@@ -99,6 +99,7 @@ class CombineReader(Readable, Seekable):
         return buffer.getvalue()  # pyre-ignore[7]
 
     def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        offset = int(offset)
         if whence == os.SEEK_SET:
             target_offset = offset
         elif whence == os.SEEK_CUR:
@@ -111,7 +112,7 @@ class CombineReader(Readable, Seekable):
         if target_offset < 0:
             raise ValueError('negative seek value %r' % target_offset)
 
-        self._offset = int(target_offset)
+        self._offset = target_offset
         return self._offset
 
     def _close(self):

--- a/megfile/lib/combine_reader.py
+++ b/megfile/lib/combine_reader.py
@@ -111,7 +111,7 @@ class CombineReader(Readable, Seekable):
         if target_offset < 0:
             raise ValueError('negative seek value %r' % target_offset)
 
-        self._offset = target_offset
+        self._offset = int(target_offset)
         return self._offset
 
     def _close(self):

--- a/megfile/lib/s3_buffered_writer.py
+++ b/megfile/lib/s3_buffered_writer.py
@@ -53,7 +53,7 @@ class S3BufferedWriter(Writable[bytes]):
         self._client = s3_client
         self._profile_name = profile_name
 
-        self._block_size = block_size
+        self._block_size = int(block_size)
         self._max_block_size = max_block_size
         self._max_buffer_size = max_buffer_size
         self._total_buffer_size = 0

--- a/megfile/lib/s3_limited_seekable_writer.py
+++ b/megfile/lib/s3_limited_seekable_writer.py
@@ -63,6 +63,7 @@ class S3LimitedSeekableWriter(S3BufferedWriter, Seekable):
         if self.closed:
             raise IOError('file already closed: %r' % self.name)
 
+        offset = int(offset)
         if whence == os.SEEK_SET:
             target_offset = offset
         elif whence == os.SEEK_CUR:
@@ -81,7 +82,7 @@ class S3LimitedSeekableWriter(S3BufferedWriter, Seekable):
                 'Can only seek inside of head, or seek to tail, target offset: %d'
                 % target_offset)
 
-        self._offset = int(target_offset)
+        self._offset = target_offset
         return self._offset
 
     def write(self, data: bytes) -> int:

--- a/megfile/lib/s3_limited_seekable_writer.py
+++ b/megfile/lib/s3_limited_seekable_writer.py
@@ -81,7 +81,7 @@ class S3LimitedSeekableWriter(S3BufferedWriter, Seekable):
                 'Can only seek inside of head, or seek to tail, target offset: %d'
                 % target_offset)
 
-        self._offset = target_offset
+        self._offset = int(target_offset)
         return self._offset
 
     def write(self, data: bytes) -> int:

--- a/megfile/lib/shadow_handler.py
+++ b/megfile/lib/shadow_handler.py
@@ -44,6 +44,7 @@ class ShadowHandler(Readable, Seekable, Writable, BaseShadowHandler):
         return get_content_size(self._file_object, intrusive=self._intrusive)
 
     def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        offset = int(offset)
         if whence == os.SEEK_SET:
             self._offset = offset
         elif whence == os.SEEK_CUR:


### PR DESCRIPTION
这里：https://github.com/numpy/numpy/issues/7126
不幸遇到，如果一个东西是uint64，一个东西是int64，block_offset就变np.float64，因为uint64没法向上变int，只能变到float，然后大家向上对齐就变float了。然后在后面for loop的时候无情报错。保险起见，建议改掉= =