### PR TITLE
fix: fix megfile ls for alias paths

### DIFF
--- a/megfile/cli.py
+++ b/megfile/cli.py
@@ -29,6 +29,7 @@ from megfile.smart import (
     smart_open,
     smart_path_join,
     smart_readlink,
+    smart_relpath,
     smart_remove,
     smart_rename,
     smart_scan_stat,
@@ -78,7 +79,7 @@ def get_echo_path(file_stat, base_path: str = "", full_path: bool = False):
     elif full_path:
         path = file_stat.path
     else:
-        path = os.path.relpath(file_stat.path, start=base_path)
+        path = smart_relpath(file_stat.path, start=base_path)
     return path
 
 

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -636,8 +636,8 @@ class URIPath(BaseURIPath):
             relative = path[len(other_path) :]
             relative = relative.lstrip("/")
             return type(self)(relative)  # pyre-ignore[19]
-        else:
-            raise ValueError("%r does not start with %r" % (path, other))
+
+        raise ValueError("%r does not start with %r" % (path, other))
 
     def with_name(self: Self, name: str) -> Self:
         """Return a new path with the name changed"""
@@ -667,8 +667,8 @@ class URIPath(BaseURIPath):
             relative = path[len(other_path) :]
             relative = relative.lstrip("/")
             return relative
-        else:
-            raise ValueError("%r does not start with %r" % (path, other_path))
+
+        raise ValueError("%r does not start with %r" % (path, other_path))
 
     def is_absolute(self) -> bool:
         return True

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -655,6 +655,21 @@ class URIPath(BaseURIPath):
         raw_suffix = self.suffix
         return self.from_path(path[: len(path) - len(raw_suffix)] + suffix)
 
+    def relpath(self, start=None):
+        """Return the relative path."""
+        if start is None:
+            raise TypeError("start is required")
+
+        other_path = self.from_path(start).path_with_protocol
+        path = self.path_with_protocol
+
+        if path.startswith(other_path):
+            relative = path[len(other_path) :]
+            relative = relative.lstrip("/")
+            return relative
+        else:
+            raise ValueError("%r does not start with %r" % (path, other_path))
+
     def is_absolute(self) -> bool:
         return True
 

--- a/megfile/smart_path.py
+++ b/megfile/smart_path.py
@@ -74,7 +74,7 @@ class SmartPath(BasePath):
             else:
                 path_without_protocol = path[len(protocol) + 3 :]
         elif isinstance(path, (BaseURIPath, SmartPath)):
-            return path.protocol, str(path)
+            return str(path.protocol), str(path)
         elif isinstance(path, (PurePath, BasePath)):
             return SmartPath._extract_protocol(fspath(path))
         else:

--- a/megfile/utils/__init__.py
+++ b/megfile/utils/__init__.py
@@ -323,7 +323,11 @@ class cached_classproperty(cached_property):
         if not hasattr(func, "lock"):
             self.lock = RLock()
 
-    def __get__(self, _, cls) -> object:
+    def __get__(  # pyre-ignore[14]
+        self,
+        _,
+        cls,  # pytype: disable=signature-mismatch
+    ) -> object:
         """
         This method gets called when a property value is requested.
         @param cls: The class type of the above instance.

--- a/megfile/utils/__init__.py
+++ b/megfile/utils/__init__.py
@@ -15,6 +15,7 @@ from io import (
     TextIOBase,
     TextIOWrapper,
 )
+from threading import RLock
 from typing import IO, Callable, Optional
 
 from megfile.utils.mutex import ProcessLocal, ThreadLocal
@@ -308,6 +309,19 @@ class cached_classproperty(cached_property):
         def prop(cls):
             return "value"
     """
+
+    def __init__(self, func: Callable) -> None:
+        """
+        This method initializes the cached_classproperty instance.
+        @param func: The function to be called when the property value is requested.
+        """
+        super().__init__(func)
+        # Python 3.12 removed the lock attribute from cached_property.
+        # Maybe we should remove this in the future.
+        # See also: https://github.com/python/cpython/pull/101890
+        #        https://github.com/python/cpython/issues/87634
+        if not hasattr(func, "lock"):
+            self.lock = RLock()
 
     def __get__(self, _, cls) -> object:
         """

--- a/tests/test_smart.py
+++ b/tests/test_smart.py
@@ -932,6 +932,11 @@ def s3_path():
 
 
 @pytest.fixture
+def s3_bucket():
+    yield "s3://bucket"
+
+
+@pytest.fixture
 def abs_path(fs):
     fs.create_file(os.path.join(os.path.dirname(__file__), "test"))
     yield os.path.join(os.path.dirname(__file__), "test")
@@ -979,11 +984,12 @@ def test_smart_realpath(s3_path, abs_path, link_path):
     assert smart.smart_realpath(link_path) == abs_path
 
 
-def test_smart_relpath(mocker, s3_path, abs_path, rel_path):
+def test_smart_relpath(mocker, s3_path, s3_bucket, abs_path, rel_path):
     mocker.patch("os.getcwd", return_value=os.path.dirname(__file__))
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(TypeError):
         assert smart.smart_relpath(s3_path) == s3_path
     assert smart.smart_relpath(abs_path, os.path.dirname(__file__)) == rel_path
+    assert smart.smart_relpath(s3_path, s3_bucket) == rel_path
 
 
 def test_smart_open_stdin(mocker):

--- a/tests/test_smart.py
+++ b/tests/test_smart.py
@@ -988,6 +988,8 @@ def test_smart_relpath(mocker, s3_path, s3_bucket, abs_path, rel_path):
     mocker.patch("os.getcwd", return_value=os.path.dirname(__file__))
     with pytest.raises(TypeError):
         assert smart.smart_relpath(s3_path) == s3_path
+    with pytest.raises(ValueError):
+        smart.smart_relpath(s3_path, abs_path)
     assert smart.smart_relpath(abs_path, os.path.dirname(__file__)) == rel_path
     assert smart.smart_relpath(s3_path, s3_bucket) == rel_path
 

--- a/tests/test_smart_path.py
+++ b/tests/test_smart_path.py
@@ -113,7 +113,7 @@ def test_extract_protocol():
     )
     assert SmartPath._extract_protocol(FS_TEST_ABSOLUTE_PATH_WITH_PROTOCOL) == (
         FSPath.protocol,
-        FS_TEST_ABSOLUTE_PATH,
+        FS_TEST_ABSOLUTE_PATH_WITH_PROTOCOL,
     )
     assert SmartPath._extract_protocol(FS_TEST_RELATIVE_PATH) == (
         FSPath.protocol,
@@ -121,23 +121,23 @@ def test_extract_protocol():
     )
     assert SmartPath._extract_protocol(FS_TEST_RELATIVE_PATH_WITH_PROTOCOL) == (
         FSPath.protocol,
-        FS_TEST_RELATIVE_PATH,
+        FS_TEST_RELATIVE_PATH_WITH_PROTOCOL,
     )
     assert SmartPath._extract_protocol(S3_TEST_PATH) == (
         S3Path.protocol,
-        S3_TEST_PATH_WITHOUT_PROTOCOL,
+        S3_TEST_PATH,
     )
     assert SmartPath._extract_protocol(HTTP_TEST_PATH) == (
         HttpPath.protocol,
-        HTTP_TEST_PATH_WITHOUT_PROTOCOL,
+        HTTP_TEST_PATH,
     )
     assert SmartPath._extract_protocol(HTTPS_TEST_PATH) == (
         HttpsPath.protocol,
-        HTTPS_TEST_PATH_WITHOUT_PROTOCOL,
+        HTTPS_TEST_PATH,
     )
     assert SmartPath._extract_protocol(STDIO_TEST_PATH) == (
         StdioPath.protocol,
-        STDIO_TEST_PATH_WITHOUT_PROTOCOL,
+        STDIO_TEST_PATH,
     )
 
     fs_path = FSPath(FS_TEST_ABSOLUTE_PATH)

--- a/tests/utils/test_init.py
+++ b/tests/utils/test_init.py
@@ -6,6 +6,7 @@ from megfile.utils import (
     _get_class,
     _is_pickle,
     binary_open,
+    cached_classproperty,
     combine,
     get_human_size,
     necessary_params,
@@ -53,6 +54,34 @@ def test_get_class():
         pass
 
     assert _get_class(Test) == _get_class(Test())
+
+
+def test_cached_classproperty():
+    class Test1:
+        count = 0
+
+        @cached_classproperty
+        def test(cls):
+            cls.count += 1
+            return cls.count
+
+    assert Test1().test == 1
+    assert Test1().test == 1
+    assert Test1.test == 1
+    assert Test1.test == 1
+
+    class Test2:
+        count = 0
+
+        @cached_classproperty
+        def test(cls):
+            cls.count += 1
+            return cls.count
+
+    assert Test2.test == 1
+    assert Test2.test == 1
+    assert Test2().test == 1
+    assert Test2().test == 1
 
 
 def test__is_pickle():


### PR DESCRIPTION
Before

```bash
$ megfile ls tos://bucket/
INFO:megfile.s3_path:using ~/.aws/config: https://tos-s3-cn-beijing.ivolces.com
../../s3:/bucket/1
../../s3:/bucket/2
```

After

```bash
$ megfile ls tos://bucket/
INFO:megfile.s3_path:using ~/.aws/config: https://tos-s3-cn-beijing.ivolces.com
1
2
```

感觉这个实现也比较苟，但科学实现改的太大有点费劲，简单讨论下

1. 现在实现只是更新了下 smart_relpath 的定义：
    1. 之前 URIPath.relpath 会抛异常，现在改成对于相同 prefix 的路径可以返回一个字符串，其他情况抛异常
    2. SmartPath.relpath 适配了一下 alias 的路径转换
    3. megfile ls 这块用 smart_relpath 代替之前的 os.path.relpath 获取相对路径
2. 这样改之后，alias 的定义会变成：
    1. smart 相关函数返回的路径和之前一样，都是 unaliased，去除 alias 的原路径
    2. smart 相关函数如果输入超过一个路径，可以处理第二个路径的 alias，例如 smart_relpath / smart_copy 等
3. 期待的科学行为的定义是（不会在这个 MR 中实现）：
    1. smart 相关函数返回的路径和之前一样，都是 aliased，即不要去除 alias 的路径
    2. 但这个定义涉及修改的接口非常多，需要有个方案设计

TODO

1. 补一下单元测试
