### PR TITLE
fix: redirect fix auth headers issue

### DIFF
--- a/megfile/config.py
+++ b/megfile/config.py
@@ -60,3 +60,5 @@ HDFS_MAX_RETRY_TIMES = int(
 SFTP_MAX_RETRY_TIMES = int(
     os.getenv("MEGFILE_SFTP_MAX_RETRY_TIMES") or DEFAULT_MAX_RETRY_TIMES
 )
+
+HTTP_AUTH_HEADERS = ("Authorization", "Www-Authenticate", "Cookie", "Cookie2")

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -76,7 +76,11 @@ class S3PrefetchReader(BasePrefetchReader):
         try:
             start, end = 0, self._block_size - 1
             first_index_response = self._fetch_response(start=start, end=end)
-            content_size = int(first_index_response["ContentRange"].split("/")[-1])
+            if "ContentRange" in first_index_response:
+                content_size = int(first_index_response["ContentRange"].split("/")[-1])
+            else:
+                # usually when read a file only have one block
+                content_size = int(first_index_response["ContentLength"])
         except S3InvalidRangeError:
             # usually when read a empty file
             # can use minio test empty file: https://hub.docker.com/r/minio/minio

--- a/megfile/utils/__init__.py
+++ b/megfile/utils/__init__.py
@@ -346,3 +346,11 @@ class cached_classproperty(cached_property):
                 val = self.func(cls)
                 setattr(cls, self.attrname, val)
         return val
+
+
+def is_domain_or_subdomain(sub, parent):
+    if sub == parent:
+        return True
+    if sub.endswith(f".{parent}"):
+        return True
+    return False

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -344,8 +344,8 @@ def test_get_s3_client(mocker):
         aws_session_token=session_token,
     )
 
-    # assert _send_request is not patched
-    assert "_send_request" not in client._endpoint.__dict__
+    # assert _send is not patched
+    assert "_send" not in client._endpoint.__dict__
 
     client = s3.get_s3_client(cache_key="test")
     assert client is s3.get_s3_client(cache_key="test")
@@ -383,8 +383,8 @@ def test_get_s3_client_v2():
         == "virtual"
     )
 
-    # assert _send_request is patched
-    assert "_send_request" in client._endpoint.__dict__
+    # assert _send is patched
+    assert "_send" in client._endpoint.__dict__
 
 
 def test_get_s3_client_from_env(mocker):
@@ -409,8 +409,8 @@ def test_get_s3_client_from_env(mocker):
         aws_session_token=session_token,
     )
 
-    # assert _send_request is patched
-    assert "_send_request" in client._endpoint.__dict__
+    # assert _send is patched
+    assert "_send" in client._endpoint.__dict__
 
 
 def test_get_s3_client_with_config(mocker):
@@ -439,8 +439,8 @@ def test_get_s3_client_with_config(mocker):
         aws_session_token=session_token,
     )
 
-    # assert _send_request is patched
-    assert "_send_request" in client._endpoint.__dict__
+    # assert _send is patched
+    assert "_send" in client._endpoint.__dict__
 
 
 def test_get_s3_session_threading(mocker):

--- a/tests/utils/test_init.py
+++ b/tests/utils/test_init.py
@@ -9,6 +9,7 @@ from megfile.utils import (
     cached_classproperty,
     combine,
     get_human_size,
+    is_domain_or_subdomain,
     necessary_params,
     patch_rlimit,
 )
@@ -108,3 +109,12 @@ def test__is_pickle():
     fileObj.name = "test"
     fileObj.mode = "wb"
     assert _is_pickle(fileObj) is False
+
+
+def test_is_domain_or_subdomain():
+    assert is_domain_or_subdomain("test1.com", "test2.com") is False
+    assert is_domain_or_subdomain("test1.test.com", "test2.test.com") is False
+
+    assert is_domain_or_subdomain("test.com", "test.com") is True
+    assert is_domain_or_subdomain("test1.test.com", "test.com") is True
+    assert is_domain_or_subdomain("test.com", "test1.test.com") is False


### PR DESCRIPTION
用起来发现有几个细节上的 bug

1. 阿里云 oss 对于不到一个 block(8M) 的文件，请求返回的 headers 里没有带 Content-Range，而是 Content-Length，所以对 S3PrefetchReader 做了一些修改
    1. 这些修改是向前兼容的，因为之前 headers 里不包含 Content-Range 时会抛 KeyError，代码并没有捕获会直接报错，因此认为之前没出现过这种情况
2. 在跳转时把 headers 里的一些鉴权相关的字段删了
    1. 跳转其他域名的时候带着源域名的鉴权信息被认为是不安全的，抄了下 go 的实现，在跳转域名发生变化时不带 auth 相关的 headers 了
    2. 为了实现这个功能，patch 了一个更靠下的函数