### PR TITLE
perf:optimize open parameter and envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ $ megfile config s3 accesskey secretkey \
 --profile tos
 
 # create alias
-$ megfile config tos s3+tos
+$ megfile alias tos s3+tos
 ```
 
 You can get the configuration from `~/.config/megfile/aliases.conf`, like:

--- a/docs/configuration/common.md
+++ b/docs/configuration/common.md
@@ -2,15 +2,11 @@ Common Configuration
 ====================
 
 ### Environment configurations
-- `MEGFILE_BLOCK_SIZE`: default block size of read and write operate, unit is bytes, default is `8MB`
-- `MEGFILE_MIN_BLOCK_SIZE`: 
-    - min write block size, unit is bytes, default is equal to `MEGFILE_BLOCK_SIZE`
-    - If you need write big size file, you should set `MEGFILE_MIN_BLOCK_SIZE` to a big value.
-- `MEGFILE_MAX_BLOCK_SIZE`: max write block size, unit is bytes, default is `128MB`
-- `MEGFILE_MAX_BUFFER_SIZE`: max read buffer size, unit is bytes, default is `128MB`
-- `MEGFILE_MAX_WORKERS`: max threads will be used, default is `32`
-- `MEGFILE_BLOCK_CAPACITY`: 
-    - default cache capacity of block, default is `16`
-    - if `MEGFILE_MAX_BUFFER_SIZE` and `MEGFILE_BLOCK_CAPACITY` are both set, `MEGFILE_BLOCK_CAPACITY` will be ignored
-- `MEGFILE_S3_CLIENT_CACHE_MODE`: s3 client cache mode, `thread_local` or `process_local`, default is `thread_local`, **it's a experimental feature.**
-- `MEGFILE_MAX_RETRY_TIMES`: default max retry times when catch error which may fix by retry, default is `10`
+- `MEGFILE_READER_BLOCK_SIZE`: default block size of read operate, unit is bytes, default is `8MB`
+- `MEGFILE_READER_MAX_BUFFER_SIZE`: max read buffer size, unit is bytes, default is `128MB`
+- `MEGFILE_WRITER_BLOCK_SIZE`:
+    - default block size of write operate, unit is bytes, default is `32MB`
+    - If you need write big size oss file, you should set to a big value.
+- `MEGFILE_WRITER_MAX_BUFFER_SIZE`: max write buffer size, unit is bytes, default is `128MB`
+- `MEGFILE_MAX_WORKERS`: max threads will be used, default is `8`
+- `MEGFILE_MAX_RETRY_TIMES`: default max retry times when catch error which may fix by retry, default is `10`.

--- a/docs/configuration/common.md
+++ b/docs/configuration/common.md
@@ -6,7 +6,7 @@ Common Configuration
 - `MEGFILE_READER_MAX_BUFFER_SIZE`: max read buffer size, unit is bytes, default is `128MB`
 - `MEGFILE_WRITER_BLOCK_SIZE`:
     - default block size of write operate, unit is bytes, default is `32MB`
-    - If you need write big size oss file, you should set to a big value.
+    - If you need write big size file in s3, you should set to a big value. Because of multi-upload in aws s3 has a maximum of 10,000 parts, so the maximum supported file size is `MEGFILE_WRITE_BLOCK_SIZE` * 10,000.
 - `MEGFILE_WRITER_MAX_BUFFER_SIZE`: max write buffer size, unit is bytes, default is `128MB`
 - `MEGFILE_MAX_WORKERS`: max threads will be used, default is `8`
 - `MEGFILE_MAX_RETRY_TIMES`: default max retry times when catch error which may fix by retry, default is `10`.

--- a/docs/configuration/s3.md
+++ b/docs/configuration/s3.md
@@ -14,6 +14,7 @@ You can use environments to setup authentication credentials for your s3 account
 - `MEGFILE_S3_MAX_RETRY_TIMES`: s3 request max retry times when catch error which may fix by retry, default is `10`
 - `AWS_S3_VERIFY`: whether to verify ssl certificate, default is `true`, set to `false` to disable
 - `AWS_S3_REDIRECT`: whether to support http redirect, it is a experimental feature and only support `GET` method now. default is `false`, set to `true` to enable
+- `MEGFILE_S3_CLIENT_CACHE_MODE`: s3 client cache mode, `thread_local` or `process_local`, default is `thread_local`, **it's a experimental feature.**
 
 ### Use command
 You can update config file with `megfile` command easyly:

--- a/megfile/cli.py
+++ b/megfile/cli.py
@@ -10,7 +10,7 @@ from functools import partial
 import click
 from tqdm import tqdm
 
-from megfile.config import DEFAULT_BLOCK_SIZE
+from megfile.config import READER_BLOCK_SIZE
 from megfile.hdfs_path import DEFAULT_HDFS_TIMEOUT
 from megfile.interfaces import FileEntry
 from megfile.lib.glob import get_non_glob_dir, has_magic
@@ -484,11 +484,11 @@ def tail(path: str, lines: int, follow: bool):
         f.seek(0, os.SEEK_SET)
 
         for current_offset in range(
-            file_size - DEFAULT_BLOCK_SIZE, 0 - DEFAULT_BLOCK_SIZE, -DEFAULT_BLOCK_SIZE
+            file_size - READER_BLOCK_SIZE, 0 - READER_BLOCK_SIZE, -READER_BLOCK_SIZE
         ):
             current_offset = max(0, current_offset)
             f.seek(current_offset)
-            block_lines = f.read(DEFAULT_BLOCK_SIZE).split(b"\n")
+            block_lines = f.read(READER_BLOCK_SIZE).split(b"\n")
             if len(line_list) > 0:
                 block_lines[-1] += line_list[0]
                 block_lines.extend(line_list[1:])

--- a/megfile/config.py
+++ b/megfile/config.py
@@ -7,7 +7,7 @@ if READER_BLOCK_SIZE <= 0:
     )
 READER_MAX_BUFFER_SIZE = int(os.getenv("MEGFILE_READER_MAX_BUFFER_SIZE") or 128 * 2**20)
 
-# Multi-upload has a maximum of 10,000 parts,
+# Multi-upload in aws s3 has a maximum of 10,000 parts,
 # so the maximum supported file size is MEGFILE_WRITE_BLOCK_SIZE * 10,000 MB,
 # the largest object that can be uploaded in a single PUT is 5 TB in aws s3.
 WRITER_BLOCK_SIZE = int(os.getenv("MEGFILE_WRITER_BLOCK_SIZE") or 32 * 2**20)
@@ -15,16 +15,9 @@ if WRITER_BLOCK_SIZE <= 0:
     raise ValueError(
         f"'MEGFILE_WRITER_BLOCK_SIZE' must bigger than 0, got {WRITER_BLOCK_SIZE}"
     )
-# Multi-upload part size must be between 5 MiB and 5 GiB.
-# There is no minimum size limit on the last part of your multipart upload.
-WRITER_MIN_BLOCK_SIZE = 8 * 2**20
 WRITER_MAX_BUFFER_SIZE = int(os.getenv("MEGFILE_WRITER_MAX_BUFFER_SIZE") or 128 * 2**20)
 
 GLOBAL_MAX_WORKERS = int(os.getenv("MEGFILE_MAX_WORKERS") or 8)
-
-# for logging the size of file had read or wrote
-BACKOFF_INITIAL = 64 * 2**20  # 64MB
-BACKOFF_FACTOR = 4
 
 NEWLINE = ord("\n")
 

--- a/megfile/config.py
+++ b/megfile/config.py
@@ -8,7 +8,7 @@ if READER_BLOCK_SIZE <= 0:
 READER_MAX_BUFFER_SIZE = int(os.getenv("MEGFILE_READER_MAX_BUFFER_SIZE") or 128 * 2**20)
 
 # Multi-upload in aws s3 has a maximum of 10,000 parts,
-# so the maximum supported file size is MEGFILE_WRITE_BLOCK_SIZE * 10,000 MB,
+# so the maximum supported file size is MEGFILE_WRITE_BLOCK_SIZE * 10,000,
 # the largest object that can be uploaded in a single PUT is 5 TB in aws s3.
 WRITER_BLOCK_SIZE = int(os.getenv("MEGFILE_WRITER_BLOCK_SIZE") or 32 * 2**20)
 if WRITER_BLOCK_SIZE <= 0:

--- a/megfile/hdfs.py
+++ b/megfile/hdfs.py
@@ -313,9 +313,10 @@ def hdfs_open(
                     Should only be used in text mode.
     :param errors: Optional string specifying how encoding and decoding errors are
                 to be handled. Cannot be used in binary mode.
-    :param max_concurrency: Maximum number of concurrent threads for reader.
-    :param max_buffer_size: Maximum cached buffer size in memory for reader,
-        default is 128MB.
+    :param max_concurrency: Max download thread number, `None` by default,
+        will use global thread pool with 8 threads.
+    :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
+        Set to `0` will disable cache.
     :param block_forward: Number of blocks of data for reader cached from the
         offset position.
     :param block_size: Size of a single block for reader, default is 8MB.

--- a/megfile/hdfs.py
+++ b/megfile/hdfs.py
@@ -297,7 +297,7 @@ def hdfs_open(
     buffering: Optional[int] = None,
     encoding: Optional[str] = None,
     errors: Optional[str] = None,
-    max_concurrency: Optional[int] = None,
+    max_workers: Optional[int] = None,
     max_buffer_size: int = READER_MAX_BUFFER_SIZE,
     block_forward: Optional[int] = None,
     block_size: int = READER_BLOCK_SIZE,
@@ -313,7 +313,7 @@ def hdfs_open(
                     Should only be used in text mode.
     :param errors: Optional string specifying how encoding and decoding errors are
                 to be handled. Cannot be used in binary mode.
-    :param max_concurrency: Max download thread number, `None` by default,
+    :param max_workers: Max download thread number, `None` by default,
         will use global thread pool with 8 threads.
     :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
         Set to `0` will disable cache.
@@ -328,7 +328,7 @@ def hdfs_open(
         buffering=buffering,
         encoding=encoding,
         errors=errors,
-        max_concurrency=max_concurrency,
+        max_workers=max_workers,
         max_buffer_size=max_buffer_size,
         block_forward=block_forward,
         block_size=block_size,

--- a/megfile/hdfs.py
+++ b/megfile/hdfs.py
@@ -1,5 +1,6 @@
 from typing import IO, BinaryIO, Iterator, List, Optional, Tuple
 
+from megfile.config import READER_BLOCK_SIZE, READER_MAX_BUFFER_SIZE
 from megfile.hdfs_path import (
     HdfsPath,
     is_hdfs,
@@ -296,10 +297,40 @@ def hdfs_open(
     buffering: Optional[int] = None,
     encoding: Optional[str] = None,
     errors: Optional[str] = None,
+    max_concurrency: Optional[int] = None,
+    max_buffer_size: int = READER_MAX_BUFFER_SIZE,
+    block_forward: Optional[int] = None,
+    block_size: int = READER_BLOCK_SIZE,
     **kwargs,
 ) -> IO:
+    """
+    Open a file on the specified path.
+
+    :param path: Given path
+    :param mode: Mode to open the file. Supports 'r', 'rb', 'w', 'wb', 'a', 'ab'.
+    :param buffering: Optional integer used to set the buffering policy.
+    :param encoding: Name of the encoding used to decode or encode the file.
+                    Should only be used in text mode.
+    :param errors: Optional string specifying how encoding and decoding errors are
+                to be handled. Cannot be used in binary mode.
+    :param max_concurrency: Maximum number of concurrent threads for reader.
+    :param max_buffer_size: Maximum cached buffer size in memory for reader,
+        default is 128MB.
+    :param block_forward: Number of blocks of data for reader cached from the
+        offset position.
+    :param block_size: Size of a single block for reader, default is 8MB.
+    :returns: A file-like object.
+    :raises ValueError: If an unacceptable mode is provided.
+    """
     return HdfsPath(path).open(
-        mode, buffering=buffering, encoding=encoding, errors=errors
+        mode,
+        buffering=buffering,
+        encoding=encoding,
+        errors=errors,
+        max_concurrency=max_concurrency,
+        max_buffer_size=max_buffer_size,
+        block_forward=block_forward,
+        block_size=block_size,
     )
 
 

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -584,9 +584,10 @@ class HdfsPath(URIPath):
                         Should only be used in text mode.
         :param errors: Optional string specifying how encoding and decoding errors are
                     to be handled. Cannot be used in binary mode.
-        :param max_concurrency: Maximum number of concurrent threads for reader.
-        :param max_buffer_size: Maximum cached buffer size in memory for reader,
-            default is 128MB.
+        :param max_concurrency: Max download thread number, `None` by default,
+            will use global thread pool with 8 threads.
+        :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
+            Set to `0` will disable cache.
         :param block_forward: Number of blocks of data for reader cached from the
             offset position.
         :param block_size: Size of a single block for reader, default is 8MB.

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -6,6 +6,11 @@ import sys
 from functools import cached_property, lru_cache
 from typing import IO, BinaryIO, Iterator, List, Optional, Tuple
 
+from megfile.config import (
+    HDFS_MAX_RETRY_TIMES,
+    READER_BLOCK_SIZE,
+    READER_MAX_BUFFER_SIZE,
+)
 from megfile.errors import _create_missing_ok_generator, raise_hdfs_error
 from megfile.interfaces import FileEntry, PathLike, StatResult, URIPath
 from megfile.lib.compat import fspath
@@ -564,8 +569,30 @@ class HdfsPath(URIPath):
         buffering: Optional[int] = None,
         encoding: Optional[str] = None,
         errors: Optional[str] = None,
+        max_concurrency: Optional[int] = None,
+        max_buffer_size: int = READER_MAX_BUFFER_SIZE,
+        block_forward: Optional[int] = None,
+        block_size: int = READER_BLOCK_SIZE,
         **kwargs,
     ) -> IO:
+        """
+        Open a file on the specified path.
+
+        :param mode: Mode to open the file. Supports 'r', 'rb', 'w', 'wb', 'a', 'ab'.
+        :param buffering: Optional integer used to set the buffering policy.
+        :param encoding: Name of the encoding used to decode or encode the file.
+                        Should only be used in text mode.
+        :param errors: Optional string specifying how encoding and decoding errors are
+                    to be handled. Cannot be used in binary mode.
+        :param max_concurrency: Maximum number of concurrent threads for reader.
+        :param max_buffer_size: Maximum cached buffer size in memory for reader,
+            default is 128MB.
+        :param block_forward: Number of blocks of data for reader cached from the
+            offset position.
+        :param block_size: Size of a single block for reader, default is 8MB.
+        :returns: A file-like object.
+        :raises ValueError: If an unacceptable mode is provided.
+        """
         if "+" in mode:
             raise ValueError("unacceptable mode: %r" % mode)
 
@@ -576,22 +603,15 @@ class HdfsPath(URIPath):
 
         with raise_hdfs_error(self.path_with_protocol):
             if mode in ("r", "rb"):
-                keys = [
-                    "block_size",
-                    "block_capacity",
-                    "block_forward",
-                    "max_retries",
-                    "max_workers",
-                ]
-                input_kwargs = {}
-                for key in keys:
-                    if key in kwargs:
-                        input_kwargs[key] = kwargs[key]
                 file_obj = HdfsPrefetchReader(
                     hdfs_path=self.path_without_protocol,
                     client=self._client,
                     profile_name=self._profile_name,
-                    **input_kwargs,
+                    block_size=block_size,
+                    max_buffer_size=max_buffer_size,
+                    block_forward=block_forward,
+                    max_retries=HDFS_MAX_RETRY_TIMES,
+                    max_workers=max_concurrency,
                 )
                 if _is_pickle(file_obj):
                     file_obj = io.BufferedReader(file_obj)  # type: ignore

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -569,7 +569,7 @@ class HdfsPath(URIPath):
         buffering: Optional[int] = None,
         encoding: Optional[str] = None,
         errors: Optional[str] = None,
-        max_concurrency: Optional[int] = None,
+        max_workers: Optional[int] = None,
         max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
         block_size: int = READER_BLOCK_SIZE,
@@ -584,7 +584,7 @@ class HdfsPath(URIPath):
                         Should only be used in text mode.
         :param errors: Optional string specifying how encoding and decoding errors are
                     to be handled. Cannot be used in binary mode.
-        :param max_concurrency: Max download thread number, `None` by default,
+        :param max_workers: Max download thread number, `None` by default,
             will use global thread pool with 8 threads.
         :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
             Set to `0` will disable cache.
@@ -612,7 +612,7 @@ class HdfsPath(URIPath):
                     max_buffer_size=max_buffer_size,
                     block_forward=block_forward,
                     max_retries=HDFS_MAX_RETRY_TIMES,
-                    max_workers=max_concurrency,
+                    max_workers=max_workers,
                 )
                 if _is_pickle(file_obj):
                     file_obj = io.BufferedReader(file_obj)  # type: ignore

--- a/megfile/http.py
+++ b/megfile/http.py
@@ -22,7 +22,7 @@ def http_open(
     *,
     encoding: Optional[str] = None,
     errors: Optional[str] = None,
-    max_concurrency: Optional[int] = None,
+    max_workers: Optional[int] = None,
     max_buffer_size: int = READER_MAX_BUFFER_SIZE,
     block_forward: Optional[int] = None,
     block_size: int = READER_BLOCK_SIZE,
@@ -41,7 +41,7 @@ def http_open(
         the file. This should only be used in text mode.
     :param errors: errors is an optional string that specifies how encoding and decoding
         errors are to be handled—this cannot be used in binary mode.
-    :param max_concurrency: Max download thread number, `None` by default,
+    :param max_workers: Max download thread number, `None` by default,
         will use global thread pool with 8 threads.
     :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
         Set to `0` will disable cache.
@@ -54,7 +54,7 @@ def http_open(
         mode,
         encoding=encoding,
         errors=errors,
-        max_concurrency=max_concurrency,
+        max_workers=max_workers,
         max_buffer_size=max_buffer_size,
         block_forward=block_forward,
         block_size=block_size,

--- a/megfile/http.py
+++ b/megfile/http.py
@@ -1,10 +1,9 @@
 from io import BufferedReader
 from typing import Optional, Union
 
-from megfile.config import DEFAULT_BLOCK_SIZE
+from megfile.config import READER_BLOCK_SIZE, READER_MAX_BUFFER_SIZE
 from megfile.http_path import HttpPath, HttpPrefetchReader, get_http_session, is_http
 from megfile.interfaces import PathLike, StatResult
-from megfile.lib.s3_buffered_writer import DEFAULT_MAX_BUFFER_SIZE
 
 __all__ = [
     "get_http_session",
@@ -24,9 +23,9 @@ def http_open(
     encoding: Optional[str] = None,
     errors: Optional[str] = None,
     max_concurrency: Optional[int] = None,
-    max_buffer_size: int = DEFAULT_MAX_BUFFER_SIZE,
-    forward_ratio: Optional[float] = None,
-    block_size: int = DEFAULT_BLOCK_SIZE,
+    max_buffer_size: int = READER_MAX_BUFFER_SIZE,
+    block_forward: Optional[int] = None,
+    block_size: int = READER_BLOCK_SIZE,
     **kwargs,
 ) -> Union[BufferedReader, HttpPrefetchReader]:
     """Open a BytesIO to read binary data of given http(s) url
@@ -44,6 +43,7 @@ def http_open(
         errors are to be handled—this cannot be used in binary mode.
     :param max_concurrency: Max download thread number, None by default
     :param max_buffer_size: Max cached buffer size in memory, 128MB by default
+    :param block_forward: How many blocks of data cached from offset position
     :param block_size: Size of single block, 8MB by default. Each block will be uploaded
         or downloaded by single thread.
     :return: BytesIO initialized with http(s) data
@@ -54,7 +54,7 @@ def http_open(
         errors=errors,
         max_concurrency=max_concurrency,
         max_buffer_size=max_buffer_size,
-        forward_ratio=forward_ratio,
+        block_forward=block_forward,
         block_size=block_size,
     )
 

--- a/megfile/http.py
+++ b/megfile/http.py
@@ -36,17 +36,19 @@ def http_open(
         and then return BytesIO to user.
 
     :param path: Given path
-    :param mode: Only supports 'rb' mode now
+    :param mode: Only supports 'r' or 'rb' mode now
     :param encoding: encoding is the name of the encoding used to decode or encode
         the file. This should only be used in text mode.
     :param errors: errors is an optional string that specifies how encoding and decoding
         errors are to be handled—this cannot be used in binary mode.
-    :param max_concurrency: Max download thread number, None by default
-    :param max_buffer_size: Max cached buffer size in memory, 128MB by default
+    :param max_concurrency: Max download thread number, `None` by default,
+        will use global thread pool with 8 threads.
+    :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
+        Set to `0` will disable cache.
     :param block_forward: How many blocks of data cached from offset position
     :param block_size: Size of single block, 8MB by default. Each block will be uploaded
         or downloaded by single thread.
-    :return: BytesIO initialized with http(s) data
+    :return: A file-like object with http(s) data
     """
     return HttpPath(path).open(
         mode,

--- a/megfile/http_path.py
+++ b/megfile/http_path.py
@@ -163,17 +163,19 @@ class HttpPath(URIPath):
             Essentially, it reads data of http(s) url to memory by requests,
             and then return BytesIO to user.
 
-        :param mode: Only supports 'rb' mode now
+        :param mode: Only supports 'r' or 'rb' mode now
         :param encoding: encoding is the name of the encoding used to decode or encode
             the file. This should only be used in text mode.
         :param errors: errors is an optional string that specifies how encoding and
             decoding errors are to be handled—this cannot be used in binary mode.
-        :param max_concurrency: Max download thread number, None by default
-        :param max_buffer_size: Max cached buffer size in memory, 128MB by default
+        :param max_concurrency: Max download thread number, `None` by default,
+            will use global thread pool with 8 threads.
+        :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
+            Set to `0` will disable cache.
         :param block_forward: How many blocks of data cached from offset position
         :param block_size: Size of single block, 8MB by default. Each block will
             be uploaded or downloaded by single thread.
-        :return: BytesIO initialized with http(s) data
+        :return: A file-like object with http(s) data
         """
         if mode not in ("rb",):
             raise ValueError("unacceptable mode: %r" % mode)

--- a/megfile/http_path.py
+++ b/megfile/http_path.py
@@ -9,12 +9,15 @@ from typing import Iterable, Iterator, Optional, Tuple, Union
 import requests
 from urllib3 import HTTPResponse
 
-from megfile.config import DEFAULT_BLOCK_SIZE, HTTP_MAX_RETRY_TIMES
+from megfile.config import (
+    HTTP_MAX_RETRY_TIMES,
+    READER_BLOCK_SIZE,
+    READER_MAX_BUFFER_SIZE,
+)
 from megfile.errors import http_should_retry, patch_method, translate_http_error
 from megfile.interfaces import PathLike, Readable, StatResult, URIPath
 from megfile.lib.compat import fspath
 from megfile.lib.http_prefetch_reader import DEFAULT_TIMEOUT, HttpPrefetchReader
-from megfile.lib.s3_buffered_writer import DEFAULT_MAX_BUFFER_SIZE
 from megfile.lib.url import get_url_scheme
 from megfile.smart_path import SmartPath
 from megfile.utils import _is_pickle, binary_open
@@ -27,7 +30,6 @@ __all__ = [
 ]
 
 _logger = get_logger(__name__)
-max_retries = HTTP_MAX_RETRY_TIMES
 
 
 def get_http_session(
@@ -106,7 +108,7 @@ def get_http_session(
 
     session.request = patch_method(
         partial(session.request, timeout=timeout),
-        max_retries=max_retries,
+        max_retries=HTTP_MAX_RETRY_TIMES,
         should_retry=http_should_retry,
         before_callback=before_callback,
         after_callback=after_callback,
@@ -149,9 +151,9 @@ class HttpPath(URIPath):
         mode: str = "rb",
         *,
         max_concurrency: Optional[int] = None,
-        max_buffer_size: int = DEFAULT_MAX_BUFFER_SIZE,
-        forward_ratio: Optional[float] = None,
-        block_size: int = DEFAULT_BLOCK_SIZE,
+        max_buffer_size: int = READER_MAX_BUFFER_SIZE,
+        block_forward: Optional[int] = None,
+        block_size: int = READER_BLOCK_SIZE,
         **kwargs,
     ) -> Union[BufferedReader, HttpPrefetchReader]:
         """Open a BytesIO to read binary data of given http(s) url
@@ -168,6 +170,7 @@ class HttpPath(URIPath):
             decoding errors are to be handled—this cannot be used in binary mode.
         :param max_concurrency: Max download thread number, None by default
         :param max_buffer_size: Max cached buffer size in memory, 128MB by default
+        :param block_forward: How many blocks of data cached from offset position
         :param block_size: Size of single block, 8MB by default. Each block will
             be uploaded or downloaded by single thread.
         :return: BytesIO initialized with http(s) data
@@ -197,20 +200,14 @@ class HttpPath(URIPath):
         ):
             response.close()
 
-            block_capacity = max_buffer_size // block_size
-            if forward_ratio is None:
-                block_forward = None
-            else:
-                block_forward = max(int(block_capacity * forward_ratio), 1)
-
             reader = HttpPrefetchReader(
                 self,
                 content_size=content_size,
-                max_retries=max_retries,
-                max_workers=max_concurrency,
-                block_capacity=block_capacity,
-                block_forward=block_forward,
                 block_size=block_size,
+                max_buffer_size=max_buffer_size,
+                block_forward=block_forward,
+                max_retries=HTTP_MAX_RETRY_TIMES,
+                max_workers=max_concurrency,
             )
             if _is_pickle(reader):
                 reader = BufferedReader(reader)  # type: ignore

--- a/megfile/http_path.py
+++ b/megfile/http_path.py
@@ -150,7 +150,7 @@ class HttpPath(URIPath):
         self,
         mode: str = "rb",
         *,
-        max_concurrency: Optional[int] = None,
+        max_workers: Optional[int] = None,
         max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
         block_size: int = READER_BLOCK_SIZE,
@@ -168,7 +168,7 @@ class HttpPath(URIPath):
             the file. This should only be used in text mode.
         :param errors: errors is an optional string that specifies how encoding and
             decoding errors are to be handled—this cannot be used in binary mode.
-        :param max_concurrency: Max download thread number, `None` by default,
+        :param max_workers: Max download thread number, `None` by default,
             will use global thread pool with 8 threads.
         :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
             Set to `0` will disable cache.
@@ -209,7 +209,7 @@ class HttpPath(URIPath):
                 max_buffer_size=max_buffer_size,
                 block_forward=block_forward,
                 max_retries=HTTP_MAX_RETRY_TIMES,
-                max_workers=max_concurrency,
+                max_workers=max_workers,
             )
             if _is_pickle(reader):
                 reader = BufferedReader(reader)  # type: ignore

--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -31,15 +31,6 @@ class SeekRecord:
 
 
 class BasePrefetchReader(Readable[bytes], Seekable, ABC):
-    """
-    Reader to fast read the remote file content.
-    This will divide the file content into equal parts of block_size size,
-    and will use LRU to cache at most block_capacity blocks in memory.
-    open(), seek() and read() will trigger prefetch read.
-    The prefetch will cached block_forward blocks of data from offset position
-    (the position after reading if the called function is read).
-    """
-
     def __init__(
         self,
         *,

--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -60,7 +60,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
             block_forward = max(block_capacity - 1, 0)
             self._is_auto_scaling = block_forward > 0
 
-        if block_capacity <= block_forward:
+        if 0 < block_capacity <= block_forward:
             raise ValueError(
                 "max_buffer_size should greater than block_forward * block_size, "
                 "got: max_buffer_size=%s, block_size=%s, block_forward=%s"

--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -39,12 +39,12 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
         max_workers: Optional[int] = None,
         **kwargs,
     ):
-        self._is_auto_scaling = False
         if max_buffer_size == 0:
             block_capacity = block_forward = 0
         else:
             block_capacity = max(max_buffer_size // block_size, 1)
 
+        self._is_auto_scaling = False
         if block_forward is None:
             block_forward = max(block_capacity - 1, 0)
             self._is_auto_scaling = block_forward > 0
@@ -316,7 +316,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
     def _seek_buffer(self, index: int, offset: int = 0):
         # The corresponding block is probably not downloaded when seek to a new position
         # So record the offset first, set it when it is accessed
-        if self._is_auto_scaling and self._block_forward > 0:  # pyre-ignore[58]
+        if self._is_auto_scaling:  # pyre-ignore[58]
             history = []
             for item in self._seek_history:
                 if item.seek_count > self._block_capacity * 2:
@@ -333,6 +333,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
                 self._block_capacity // len(self._seek_history), 0
             )
             if self._block_forward == 0:
+                self._is_auto_scaling = False
                 self._seek_history = []
 
         self._cached_offset = offset

--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -316,7 +316,7 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
     def _seek_buffer(self, index: int, offset: int = 0):
         # The corresponding block is probably not downloaded when seek to a new position
         # So record the offset first, set it when it is accessed
-        if self._is_auto_scaling:  # pyre-ignore[58]
+        if self._is_auto_scaling:
             history = []
             for item in self._seek_history:
                 if item.seek_count > self._block_capacity * 2:

--- a/megfile/lib/hdfs_prefetch_reader.py
+++ b/megfile/lib/hdfs_prefetch_reader.py
@@ -2,9 +2,9 @@ from io import BytesIO
 from typing import Optional
 
 from megfile.config import (
-    DEFAULT_BLOCK_CAPACITY,
-    DEFAULT_BLOCK_SIZE,
     HDFS_MAX_RETRY_TIMES,
+    READER_BLOCK_SIZE,
+    READER_MAX_BUFFER_SIZE,
 )
 from megfile.errors import raise_hdfs_error
 from megfile.lib.base_prefetch_reader import BasePrefetchReader
@@ -26,8 +26,8 @@ class HdfsPrefetchReader(BasePrefetchReader):
         hdfs_path: str,
         *,
         client,
-        block_size: int = DEFAULT_BLOCK_SIZE,
-        block_capacity: int = DEFAULT_BLOCK_CAPACITY,
+        block_size: int = READER_BLOCK_SIZE,
+        max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
         max_retries: int = HDFS_MAX_RETRY_TIMES,
         max_workers: Optional[int] = None,
@@ -39,7 +39,7 @@ class HdfsPrefetchReader(BasePrefetchReader):
 
         super().__init__(
             block_size=block_size,
-            block_capacity=block_capacity,
+            max_buffer_size=max_buffer_size,
             block_forward=block_forward,
             max_retries=max_retries,
             max_workers=max_workers,

--- a/megfile/lib/hdfs_prefetch_reader.py
+++ b/megfile/lib/hdfs_prefetch_reader.py
@@ -13,8 +13,8 @@ from megfile.lib.base_prefetch_reader import BasePrefetchReader
 class HdfsPrefetchReader(BasePrefetchReader):
     """
     Reader to fast read the hdfs content. This will divide the file content into equal
-    parts of block_size size, and will use LRU to cache at most block_capacity blocks
-    in memory.
+    parts of block_size size, and will use LRU to cache at most blocks in
+    max_buffer_size memory.
 
     open(), seek() and read() will trigger prefetch read. The prefetch will cached
     block_forward blocks of data from offset position (the position after reading

--- a/megfile/lib/http_prefetch_reader.py
+++ b/megfile/lib/http_prefetch_reader.py
@@ -4,9 +4,9 @@ from typing import Optional
 import requests
 
 from megfile.config import (
-    DEFAULT_BLOCK_CAPACITY,
-    DEFAULT_BLOCK_SIZE,
     HTTP_MAX_RETRY_TIMES,
+    READER_BLOCK_SIZE,
+    READER_MAX_BUFFER_SIZE,
 )
 from megfile.errors import (
     HttpBodyIncompleteError,
@@ -39,8 +39,8 @@ class HttpPrefetchReader(BasePrefetchReader):
         url: PathLike,
         *,
         content_size: Optional[int] = None,
-        block_size: int = DEFAULT_BLOCK_SIZE,
-        block_capacity: int = DEFAULT_BLOCK_CAPACITY,
+        block_size: int = READER_BLOCK_SIZE,
+        max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
         max_retries: int = HTTP_MAX_RETRY_TIMES,
         max_workers: Optional[int] = None,
@@ -50,7 +50,7 @@ class HttpPrefetchReader(BasePrefetchReader):
 
         super().__init__(
             block_size=block_size,
-            block_capacity=block_capacity,
+            max_buffer_size=max_buffer_size,
             block_forward=block_forward,
             max_retries=max_retries,
             max_workers=max_workers,

--- a/megfile/lib/http_prefetch_reader.py
+++ b/megfile/lib/http_prefetch_reader.py
@@ -26,7 +26,7 @@ class HttpPrefetchReader(BasePrefetchReader):
     Reader to fast read the http content, service must support Accept-Ranges.
 
     This will divide the file content into equal parts of block_size size, and will use
-    LRU to cache at most block_capacity blocks in memory.
+    LRU to cache at most blocks in max_buffer_size memory.
 
     open(), seek() and read() will trigger prefetch read.
 

--- a/megfile/lib/s3_buffered_writer.py
+++ b/megfile/lib/s3_buffered_writer.py
@@ -160,8 +160,7 @@ class S3BufferedWriter(Writable[bytes]):
         self._total_buffer_size += len(content)
 
         while (
-            self._uploading_futures
-            and self._total_buffer_size >= self._max_buffer_size
+            self._uploading_futures and self._total_buffer_size >= self._max_buffer_size
         ):
             wait_result = wait(self._uploading_futures, return_when=FIRST_COMPLETED)
             for future in wait_result.done:

--- a/megfile/lib/s3_buffered_writer.py
+++ b/megfile/lib/s3_buffered_writer.py
@@ -37,6 +37,8 @@ class PartResult(_PartResult):
 
 
 class S3BufferedWriter(Writable[bytes]):
+    # Multi-upload part size must be between 5 MiB and 5 GiB.
+    # There is no minimum size limit on the last part of your multipart upload.
     MIN_BLOCK_SIZE = 8 * 2**20
 
     def __init__(

--- a/megfile/lib/s3_limited_seekable_writer.py
+++ b/megfile/lib/s3_limited_seekable_writer.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 from megfile.config import (
     WRITER_MAX_BUFFER_SIZE,
-    WRITER_MIN_BLOCK_SIZE,
 )
 from megfile.errors import raise_s3_error
 from megfile.interfaces import Seekable
@@ -28,7 +27,7 @@ class S3LimitedSeekableWriter(S3BufferedWriter, Seekable):
         key: str,
         *,
         s3_client,
-        block_size: int = WRITER_MIN_BLOCK_SIZE,
+        block_size: int = S3BufferedWriter.MIN_BLOCK_SIZE,
         head_block_size: Optional[int] = None,
         tail_block_size: Optional[int] = None,
         max_buffer_size: int = WRITER_MAX_BUFFER_SIZE,

--- a/megfile/lib/s3_limited_seekable_writer.py
+++ b/megfile/lib/s3_limited_seekable_writer.py
@@ -4,9 +4,8 @@ from logging import getLogger as get_logger
 from typing import Optional
 
 from megfile.config import (
-    DEFAULT_MAX_BLOCK_SIZE,
-    DEFAULT_MAX_BUFFER_SIZE,
-    DEFAULT_MIN_BLOCK_SIZE,
+    WRITER_MAX_BUFFER_SIZE,
+    WRITER_MIN_BLOCK_SIZE,
 )
 from megfile.errors import raise_s3_error
 from megfile.interfaces import Seekable
@@ -29,11 +28,10 @@ class S3LimitedSeekableWriter(S3BufferedWriter, Seekable):
         key: str,
         *,
         s3_client,
-        block_size: int = DEFAULT_MIN_BLOCK_SIZE,
+        block_size: int = WRITER_MIN_BLOCK_SIZE,
         head_block_size: Optional[int] = None,
         tail_block_size: Optional[int] = None,
-        max_block_size: int = DEFAULT_MAX_BLOCK_SIZE,
-        max_buffer_size: int = DEFAULT_MAX_BUFFER_SIZE,
+        max_buffer_size: int = WRITER_MAX_BUFFER_SIZE,
         max_workers: Optional[int] = None,
         profile_name: Optional[str] = None,
     ):
@@ -42,7 +40,6 @@ class S3LimitedSeekableWriter(S3BufferedWriter, Seekable):
             key,
             s3_client=s3_client,
             block_size=block_size,
-            max_block_size=max_block_size,
             max_buffer_size=max_buffer_size,
             max_workers=max_workers,
             profile_name=profile_name,

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -3,12 +3,8 @@ from io import BytesIO
 from typing import Optional
 
 from megfile.config import (
-    BACKOFF_FACTOR,
-    BACKOFF_INITIAL,
-    DEFAULT_BLOCK_CAPACITY,
-    DEFAULT_BLOCK_SIZE,
-    GLOBAL_MAX_WORKERS,
-    NEWLINE,
+    READER_BLOCK_SIZE,
+    READER_MAX_BUFFER_SIZE,
     S3_MAX_RETRY_TIMES,
 )
 from megfile.errors import (
@@ -21,12 +17,6 @@ from megfile.errors import (
 from megfile.lib.base_prefetch_reader import BasePrefetchReader, LRUCacheFutureManager
 
 __all__ = [
-    "DEFAULT_BLOCK_CAPACITY",
-    "DEFAULT_BLOCK_SIZE",
-    "GLOBAL_MAX_WORKERS",
-    "BACKOFF_INITIAL",
-    "BACKOFF_FACTOR",
-    "NEWLINE",
     "S3PrefetchReader",
     "LRUCacheFutureManager",
 ]
@@ -50,8 +40,8 @@ class S3PrefetchReader(BasePrefetchReader):
         key: str,
         *,
         s3_client,
-        block_size: int = DEFAULT_BLOCK_SIZE,
-        block_capacity: int = DEFAULT_BLOCK_CAPACITY,
+        block_size: int = READER_BLOCK_SIZE,
+        max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
         max_retries: int = S3_MAX_RETRY_TIMES,
         max_workers: Optional[int] = None,
@@ -66,7 +56,7 @@ class S3PrefetchReader(BasePrefetchReader):
 
         super().__init__(
             block_size=block_size,
-            block_capacity=block_capacity,
+            max_buffer_size=max_buffer_size,
             block_forward=block_forward,
             max_retries=max_retries,
             max_workers=max_workers,

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -77,9 +77,10 @@ class S3PrefetchReader(BasePrefetchReader):
             first_index_response = self._fetch_response()
             content_size = int(first_index_response["ContentLength"])
 
-        first_future = Future()
-        first_future.set_result(first_index_response["Body"])
-        self._insert_futures(index=0, future=first_future)
+        if self._block_capacity > 0:
+            first_future = Future()
+            first_future.set_result(first_index_response["Body"])
+            self._insert_futures(index=0, future=first_future)
         self._content_etag = first_index_response["ETag"]
         self._content_info = first_index_response
         return content_size

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -27,7 +27,7 @@ class S3PrefetchReader(BasePrefetchReader):
     Reader to fast read the s3 content.
 
     This will divide the file content into equalparts of block_size size,
-    and will use LRU to cache at most block_capacity blocks in memory.
+    and will use LRU to cache at most blocks in max_buffer_size memory.
 
     open(), seek() and read() will trigger prefetch read.
     The prefetch will cached block_forward blocks of data from offset position

--- a/megfile/lib/s3_share_cache_reader.py
+++ b/megfile/lib/s3_share_cache_reader.py
@@ -4,14 +4,17 @@ from logging import getLogger as get_logger
 from typing import Optional
 
 from megfile.config import (
-    DEFAULT_BLOCK_CAPACITY,
-    DEFAULT_BLOCK_SIZE,
+    READER_BLOCK_SIZE,
+    READER_MAX_BUFFER_SIZE,
     S3_MAX_RETRY_TIMES,
 )
 from megfile.lib.s3_prefetch_reader import LRUCacheFutureManager, S3PrefetchReader
 from megfile.utils import thread_local
 
 _logger = get_logger(__name__)
+
+
+DEFAULT_BLOCK_CAPACITY = max(READER_MAX_BUFFER_SIZE // READER_BLOCK_SIZE, 1)
 
 
 class S3ShareCacheReader(S3PrefetchReader):
@@ -32,8 +35,8 @@ class S3ShareCacheReader(S3PrefetchReader):
         key: str,
         *,
         s3_client,
-        block_size: int = DEFAULT_BLOCK_SIZE,
-        block_capacity: int = DEFAULT_BLOCK_CAPACITY,
+        block_size: int = READER_BLOCK_SIZE,
+        max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
         max_retries: int = S3_MAX_RETRY_TIMES,
         cache_key: str = "lru",
@@ -47,7 +50,7 @@ class S3ShareCacheReader(S3PrefetchReader):
             key,
             s3_client=s3_client,
             block_size=block_size,
-            block_capacity=block_capacity,
+            max_buffer_size=max_buffer_size,
             block_forward=block_forward,
             max_retries=max_retries,
             max_workers=max_workers,

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -710,10 +710,6 @@ class BasePath:
         """Write the opened binary stream to the path."""
         raise NotImplementedError('method "save" not implemented: %r' % self)
 
-    def relpath(self, start=None):
-        """Return the relative path."""
-        raise NotImplementedError('method "relpath" not implemented: %r' % self)
-
     def chmod(self, mode: int, *, follow_symlinks: bool = True):
         raise NotImplementedError(f"'chmod' is unsupported on '{type(self)}'")
 

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -686,7 +686,7 @@ def s3_prefetch_open(
     mode: str = "rb",
     followlinks: bool = False,
     *,
-    max_concurrency: Optional[int] = None,
+    max_workers: Optional[int] = None,
     block_size: int = READER_BLOCK_SIZE,
 ) -> S3PrefetchReader:
     """Open a asynchronous prefetch reader, to support fast sequential
@@ -698,7 +698,7 @@ def s3_prefetch_open(
 
         Supports context manager
 
-        Some parameter setting may perform well: max_concurrency=10 or 20,
+        Some parameter setting may perform well: max_workers=10 or 20,
         block_size=8 or 16 MB, default value None means using global thread pool
 
     :param s3_url: s3 path
@@ -708,7 +708,7 @@ def s3_prefetch_open(
     :param errors: errors is an optional string that specifies how encoding and
         decoding errors are to be handled—this cannot be used in binary mode.
     :param followlinks: follow symbolic link, default `False`
-    :param max_concurrency: Max download thread number, `None` by default
+    :param max_workers: Max download thread number, `None` by default
     :param block_size: Max data size downloaded by each thread, in bytes,
         8MB by default
     :returns: An opened S3PrefetchReader object
@@ -732,7 +732,7 @@ def s3_prefetch_open(
         key,
         s3_client=client,
         max_retries=max_retries,
-        max_workers=max_concurrency,
+        max_workers=max_workers,
         block_size=block_size,
         profile_name=s3_url._profile_name,
     )
@@ -745,7 +745,7 @@ def s3_share_cache_open(
     followlinks: bool = False,
     *,
     cache_key: str = "lru",
-    max_concurrency: Optional[int] = None,
+    max_workers: Optional[int] = None,
     block_size: int = READER_BLOCK_SIZE,
 ) -> S3ShareCacheReader:
     """Open a asynchronous prefetch reader, to support fast sequential read and
@@ -757,7 +757,7 @@ def s3_share_cache_open(
 
         Supports context manager
 
-        Some parameter setting may perform well: max_concurrency=10 or 20,
+        Some parameter setting may perform well: max_workers=10 or 20,
         block_size=8 or 16 MB, default value None means using global thread pool
 
     :param s3_url: s3 path
@@ -767,7 +767,7 @@ def s3_share_cache_open(
     :param errors: errors is an optional string that specifies how encoding and
         decoding errors are to be handled—this cannot be used in binary mode.
     :param followlinks: follow symbolic link, default `False`
-    :param max_concurrency: Max download thread number, None by default
+    :param max_workers: Max download thread number, None by default
     :param block_size: Max data size downloaded by each thread, in bytes,
         8MB by default
     :returns: An opened S3ShareCacheReader object
@@ -793,7 +793,7 @@ def s3_share_cache_open(
         cache_key=cache_key,
         s3_client=client,
         max_retries=max_retries,
-        max_workers=max_concurrency,
+        max_workers=max_workers,
         block_size=block_size,
         profile_name=s3_url._profile_name,
     )
@@ -917,7 +917,7 @@ def s3_buffered_open(
     mode: str,
     followlinks: bool = False,
     *,
-    max_concurrency: Optional[int] = None,
+    max_workers: Optional[int] = None,
     max_buffer_size: Optional[int] = None,
     block_forward: Optional[int] = None,
     block_size: Optional[int] = None,
@@ -934,7 +934,7 @@ def s3_buffered_open(
 
         Supports context manager
 
-        Some parameter setting may perform well: max_concurrency=10 or 20,
+        Some parameter setting may perform well: max_workers=10 or 20,
         default value None means using global thread pool
 
     :param s3_url: s3 path
@@ -945,7 +945,7 @@ def s3_buffered_open(
     :param errors: errors is an optional string that specifies how encoding and
         decoding errors are to be handled—this cannot be used in binary mode.
     :param followlinks: follow symbolic link, default `False`
-    :param max_concurrency: Max download / upload thread number, `None` by default,
+    :param max_workers: Max download / upload thread number, `None` by default,
         will use global thread pool with 8 threads.
     :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
         Set to `0` will disable cache.
@@ -995,7 +995,7 @@ def s3_buffered_open(
                 cache_key=share_cache_key,
                 s3_client=client,
                 max_retries=max_retries,
-                max_workers=max_concurrency,
+                max_workers=max_workers,
                 block_size=block_size or READER_BLOCK_SIZE,
                 block_forward=block_forward,
                 profile_name=s3_url._profile_name,
@@ -1006,7 +1006,7 @@ def s3_buffered_open(
                 key,
                 s3_client=client,
                 max_retries=max_retries,
-                max_workers=max_concurrency,
+                max_workers=max_workers,
                 max_buffer_size=max_buffer_size or READER_MAX_BUFFER_SIZE,
                 block_forward=block_forward,
                 block_size=block_size or READER_BLOCK_SIZE,
@@ -1021,7 +1021,7 @@ def s3_buffered_open(
             bucket,
             key,
             s3_client=client,
-            max_workers=max_concurrency,
+            max_workers=max_workers,
             block_size=block_size or WRITER_BLOCK_SIZE,
             max_buffer_size=max_buffer_size or WRITER_MAX_BUFFER_SIZE,
             profile_name=s3_url._profile_name,
@@ -1031,7 +1031,7 @@ def s3_buffered_open(
             bucket,
             key,
             s3_client=client,
-            max_workers=max_concurrency,
+            max_workers=max_workers,
             block_size=block_size or WRITER_BLOCK_SIZE,
             max_buffer_size=max_buffer_size or WRITER_MAX_BUFFER_SIZE,
             profile_name=s3_url._profile_name,

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -701,7 +701,14 @@ def s3_prefetch_open(
         Some parameter setting may perform well: max_concurrency=10 or 20,
         block_size=8 or 16 MB, default value None means using global thread pool
 
-    :param max_concurrency: Max download thread number, None by default
+    :param s3_url: s3 path
+    :param mode: only support "r" or "rb"
+    :param encoding: encoding is the name of the encoding used to decode or encode
+        the file. This should only be used in text mode.
+    :param errors: errors is an optional string that specifies how encoding and
+        decoding errors are to be handled—this cannot be used in binary mode.
+    :param followlinks: follow symbolic link, default `False`
+    :param max_concurrency: Max download thread number, `None` by default
     :param block_size: Max data size downloaded by each thread, in bytes,
         8MB by default
     :returns: An opened S3PrefetchReader object
@@ -753,6 +760,13 @@ def s3_share_cache_open(
         Some parameter setting may perform well: max_concurrency=10 or 20,
         block_size=8 or 16 MB, default value None means using global thread pool
 
+    :param s3_url: s3 path
+    :param mode: only support "r" or "rb"
+    :param encoding: encoding is the name of the encoding used to decode or encode
+        the file. This should only be used in text mode.
+    :param errors: errors is an optional string that specifies how encoding and
+        decoding errors are to be handled—this cannot be used in binary mode.
+    :param followlinks: follow symbolic link, default `False`
     :param max_concurrency: Max download thread number, None by default
     :param block_size: Max data size downloaded by each thread, in bytes,
         8MB by default
@@ -807,7 +821,13 @@ def s3_pipe_open(
         But asynchronous behavior can guarantee the file are successfully written,
         and frequent execution may cause thread and file handle exhaustion
 
-    :param mode: Mode to open file, either "rb" or "wb"
+    :param s3_url: s3 path
+    :param mode: Mode to open file, either "r", "rb", "w" or "wb"
+    :param encoding: encoding is the name of the encoding used to decode or encode
+        the file. This should only be used in text mode.
+    :param errors: errors is an optional string that specifies how encoding and
+        decoding errors are to be handled—this cannot be used in binary mode.
+    :param followlinks: follow symbolic link, default `False`
     :param join_thread: If wait after function execution until s3 finishes writing
     :returns: An opened BufferedReader / BufferedWriter object
     """
@@ -857,7 +877,14 @@ def s3_cached_open(
         cache_path can specify the path of cache file. Performance could be better
         if cache file path is on ssd or tmpfs
 
-    :param mode: Mode to open file, could be one of "rb", "wb" or "ab"
+    :param s3_url: s3 path
+    :param mode: Mode to open file, could be one of "rb", "wb", "ab", "rb+", "wb+"
+        or "ab+"
+    :param encoding: encoding is the name of the encoding used to decode or encode
+        the file. This should only be used in text mode.
+    :param errors: errors is an optional string that specifies how encoding and
+        decoding errors are to be handled—this cannot be used in binary mode.
+    :param followlinks: follow symbolic link, default `False`
     :param cache_path: cache file path
     :returns: An opened BufferedReader / BufferedWriter object
     """
@@ -910,8 +937,18 @@ def s3_buffered_open(
         Some parameter setting may perform well: max_concurrency=10 or 20,
         default value None means using global thread pool
 
-    :param max_concurrency: Max download thread number, None by default
-    :param max_buffer_size: Max cached buffer size in memory, 128MB by default
+    :param s3_url: s3 path
+    :param mode: Mode to open file, could be one of "rb", "wb", "ab", "rb+", "wb+"
+        or "ab+"
+    :param encoding: encoding is the name of the encoding used to decode or encode
+        the file. This should only be used in text mode.
+    :param errors: errors is an optional string that specifies how encoding and
+        decoding errors are to be handled—this cannot be used in binary mode.
+    :param followlinks: follow symbolic link, default `False`
+    :param max_concurrency: Max download / upload thread number, `None` by default,
+        will use global thread pool with 8 threads.
+    :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
+        Set to `0` will disable cache.
     :param block_forward: How many blocks of data cached from offset position, only for
         read mode.
     :param block_size: Size of single block.
@@ -920,7 +957,7 @@ def s3_buffered_open(
         (both file head part and tail part can seek block_size).
         Notes: This parameter are valid only for write-handle.
         Read-handle support arbitrary seek
-    :returns: An opened S3PrefetchReader object
+    :returns: An opened File object
     :raises: S3FileNotFoundError
     """
     if mode not in ("rb", "wb", "ab", "rb+", "wb+", "ab+"):

--- a/megfile/smart.py
+++ b/megfile/smart.py
@@ -708,7 +708,7 @@ def smart_open(
     :param followlinks: follow symbolic link, default `False`. Only be used when support
     :param s3_open_func: Function used to open s3_url. Require the function includes
         2 necessary parameters, file path and mode. only be used in s3 path.
-    :param max_concurrency: Max download / upload thread number, `None` by default,
+    :param max_workers: Max download / upload thread number, `None` by default,
         will use global thread pool with 8 threads. Only be used in s3, http, hdfs.
     :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
         Set to `0` will disable cache. Only be used in s3, http, hdfs.

--- a/megfile/smart.py
+++ b/megfile/smart.py
@@ -671,9 +671,10 @@ def smart_makedirs(path: PathLike, exist_ok: bool = False) -> None:
 def smart_open(
     path: PathLike,
     mode: str = "r",
-    s3_open_func: Callable[[str, str], BinaryIO] = s3_open,
     encoding: Optional[str] = None,
     errors: Optional[str] = None,
+    *,
+    s3_open_func: Callable[[str, str], BinaryIO] = s3_open,
     **options,
 ) -> IO:
     r"""
@@ -684,16 +685,6 @@ def smart_open(
         On fs, the difference between this function and ``io.open`` is that
         this function create directories automatically, instead of
         raising FileNotFoundError
-
-    Currently, supported protocols are:
-
-    1. s3:      "s3://<bucket>/<key>"
-
-    2. http(s): http(s) url
-
-    3. stdio:   "stdio://-"
-
-    4. FS file: Besides above mentioned protocols, other path are considered fs path
 
     Here are a few examples: ::
 
@@ -708,12 +699,24 @@ def smart_open(
 
     :param path: Given path
     :param mode: Mode to open file, supports r'[rwa][tb]?\+?'
-    :param s3_open_func: Function used to open s3_url. Require the function includes 2
-        necessary parameters, file path and mode
     :param encoding: encoding is the name of the encoding used to decode or encode
         the file. This should only be used in text mode.
     :param errors: errors is an optional string that specifies how encoding and decoding
         errors are to be handled—this cannot be used in binary mode.
+    :param buffering: buffering is an optional integer used to
+        set the buffering policy. Only be used when support.
+    :param followlinks: follow symbolic link, default `False`. Only be used when support
+    :param s3_open_func: Function used to open s3_url. Require the function includes
+        2 necessary parameters, file path and mode. only be used in s3 path.
+    :param max_concurrency: Max download / upload thread number, `None` by default,
+        will use global thread pool with 8 threads. Only be used in s3, http, hdfs.
+    :param max_buffer_size: Max cached buffer size in memory, 128MB by default.
+        Set to `0` will disable cache. Only be used in s3, http, hdfs.
+    :param block_forward: How many blocks of data cached from offset position, only for
+        read mode. Only be used in s3, http, hdfs.
+    :param block_size: Size of single block. Each block will be uploaded by single
+        thread. Only be used in s3, http, hdfs.
+
     :returns: File-Like object
     :raises: FileNotFoundError, IsADirectoryError, ValueError
     """

--- a/megfile/smart_path.py
+++ b/megfile/smart_path.py
@@ -155,7 +155,7 @@ class SmartPath(BasePath):
         :returns: Relative path from start
         """
         if start is not None:
-            _, start = SmartPath._extract_protocol(fspath(start))
+            _, start = SmartPath._extract_protocol(fspath(start))  # pyre-ignore[9]
         return self.pathlike.relpath(start=start)
 
     as_uri = _bind_function("as_uri")

--- a/megfile/utils/__init__.py
+++ b/megfile/utils/__init__.py
@@ -343,7 +343,7 @@ class cached_classproperty(cached_property):
             val = cls.__dict__[self.attrname]
             if val is self:
                 val = self.func(cls)
-                setattr(cls, self.attrname, val)
+                setattr(cls, self.attrname, val)  # pyre-ignore[6]
         return val
 
 

--- a/scripts/print_pyre_errors_by_file.py
+++ b/scripts/print_pyre_errors_by_file.py
@@ -1,0 +1,24 @@
+import json
+import os
+
+if __name__ == "__main__":
+    file_path = os.path.join(os.path.dirname(__file__), "..", "pyre-sarif.json")
+    with open(file_path) as f:
+        data = json.load(f)
+
+    index = 1
+    for run in data["runs"]:
+        for result in run["results"]:
+            print(f'[{index}] {result["message"]["text"]}')
+            for location in result["locations"]:
+                print(
+                    ":".join(
+                        [
+                            location["physicalLocation"]["artifactLocation"]["uri"],
+                            str(location["physicalLocation"]["region"]["startLine"]),
+                            str(location["physicalLocation"]["region"]["startColumn"]),
+                        ]
+                    )
+                )
+            index += 1
+            print("\n")

--- a/tests/lib/test_glob.py
+++ b/tests/lib/test_glob.py
@@ -138,7 +138,7 @@ def _glob_with_recursive_pathname():
     assert_glob(
         "/bucketForGlobTest/**",
         [
-            "/bucketForGlobTest/",  # TODO: remove it
+            "/bucketForGlobTest/",
             "/bucketForGlobTest/1",
             "/bucketForGlobTest/1/a",
             "/bucketForGlobTest/1/a/b",

--- a/tests/lib/test_http_prefetch_reader.py
+++ b/tests/lib/test_http_prefetch_reader.py
@@ -183,7 +183,6 @@ def test_http_prefetch_reader_read_readline_mix(mocker):
 
 def test_http_prefetch_reader_seek_out_of_range(mocker):
     content = b"1\n2\n3\n4\n"
-    mocker.patch("megfile.lib.base_prefetch_reader.BACKOFF_INITIAL", 4)
     mocker.patch(
         "megfile.http_path.requests.get", return_value=FakeResponse200(b"1\n2\n3\n4\n")
     )
@@ -196,7 +195,6 @@ def test_http_prefetch_reader_seek_out_of_range(mocker):
         reader.seek(100)
         assert reader.tell() == 8
         assert reader.read(2) == b""
-        assert reader._backoff_size == 16
 
         with pytest.raises(ValueError):
             reader.seek(0, "error_whence")

--- a/tests/lib/test_http_prefetch_reader.py
+++ b/tests/lib/test_http_prefetch_reader.py
@@ -272,6 +272,65 @@ def test_http_prefetch_reader_backward_seek_and_the_target_in_remains(
         assert reader._cached_blocks == [2, 1, 0]
 
 
+def test_http_prefetch_reader_max_buffer_size_eq_0(http_patch, mocker):
+    """目标 offset 在 remains 中 重置 remains 位置"""
+    with HttpPrefetchReader(
+        URL,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=3,
+        max_buffer_size=0,
+    ) as reader:
+        assert reader._cached_blocks == []
+
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == []
+
+        reader.seek(3)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == []
+
+        reader.seek(1)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == []
+
+
+def test_http_prefetch_reader_block_forward_eq_0(http_patch, mocker):
+    """目标 offset 在 remains 中 重置 remains 位置"""
+    with HttpPrefetchReader(
+        URL,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=3,
+        max_buffer_size=3,
+        block_forward=0,
+    ) as reader:
+        assert reader._block_forward == 0
+        assert reader._cached_blocks == []
+
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == [0]
+
+        reader.seek(3)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == [1]
+
+        reader.seek(9)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == [3]
+
+        reader.seek(1)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == [0]
+
+
 def test_http_prefetch_reader_backward_block_forward_eq_1(http_patch, mocker):
     class FakeHistory:
         read_count = 1

--- a/tests/lib/test_http_prefetch_reader.py
+++ b/tests/lib/test_http_prefetch_reader.py
@@ -5,6 +5,7 @@ from io import BytesIO
 import pytest
 import requests
 
+from megfile.config import READER_BLOCK_SIZE
 from megfile.lib.http_prefetch_reader import HttpPrefetchReader
 
 URL = "http://test"
@@ -251,19 +252,19 @@ def test_http_prefetch_reader_backward_seek_and_the_target_in_remains(
         content_size=CONTENT_SIZE,
         max_workers=2,
         block_size=3,
-        block_capacity=3,
+        max_buffer_size=3 * 3,
         block_forward=2,
     ) as reader:
         assert reader._cached_blocks == []
 
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [1, 0]
+        assert reader._cached_blocks == [2, 1, 0]
 
         reader.seek(3)
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [0, 2, 1]
+        assert reader._cached_blocks == [3, 2, 1]
 
         reader.seek(1)
         reader._buffer
@@ -280,18 +281,18 @@ def test_http_prefetch_reader_backward_block_forward_eq_1(http_patch, mocker):
         content_size=CONTENT_SIZE,
         max_workers=2,
         block_size=3,
-        block_capacity=3,
+        max_buffer_size=3 * 3,
         block_forward=1,
     ) as reader:
         assert reader.read(6) == b"block0"
-        assert reader._cached_blocks == []
+        assert reader._cached_blocks == [0, 2, 1]
 
         reader._seek_history = [FakeHistory()]
         assert reader.read(7) == b" block1"
-        assert reader._cached_blocks == []
+        assert reader._cached_blocks == [3, 5, 4]
 
         assert reader.read(7) == b" block2"
-        assert reader._cached_blocks == [4, 5, 6]
+        assert reader._cached_blocks == [5, 7, 6]
 
 
 def test_http_prefetch_reader_backward_seek_and_the_target_out_of_remains(http_patch):
@@ -304,24 +305,24 @@ def test_http_prefetch_reader_backward_seek_and_the_target_out_of_remains(http_p
         content_size=CONTENT_SIZE,
         max_workers=2,
         block_size=3,
-        block_capacity=3,
+        max_buffer_size=3 * 3,
         block_forward=2,
     ) as reader:  # buffer 最大为 6B
         assert reader._cached_blocks == []
 
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [1, 0]
+        assert reader._cached_blocks == [2, 1, 0]
 
         reader.seek(10)
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [0, 4, 3]
+        assert reader._cached_blocks == [5, 4, 3]
 
         reader.seek(0)
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [3, 1, 0]
+        assert reader._cached_blocks == [2, 1, 0]
 
 
 def test_http_prefetch_reader_seek_and_the_target_in_buffer(http_patch, mocker):
@@ -334,29 +335,29 @@ def test_http_prefetch_reader_seek_and_the_target_in_buffer(http_patch, mocker):
         content_size=CONTENT_SIZE,
         max_workers=3,
         block_size=3,
-        block_capacity=3,
+        max_buffer_size=3 * 3,
         block_forward=2,
     ) as reader:  # buffer 最长为 9B
         assert reader._cached_blocks == []
 
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [1, 0]
+        assert reader._cached_blocks == [2, 1, 0]
 
         reader.seek(1)
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [1, 0]
+        assert reader._cached_blocks == [2, 1, 0]
 
         reader.seek(5)
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [0, 2, 1]
+        assert reader._cached_blocks == [3, 2, 1]
 
         reader.seek(10)
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [1, 4, 3]
+        assert reader._cached_blocks == [5, 4, 3]
 
 
 def test_http_prefetch_reader_seek_and_the_target_out_of_buffer(http_patch):
@@ -369,19 +370,19 @@ def test_http_prefetch_reader_seek_and_the_target_out_of_buffer(http_patch):
         content_size=CONTENT_SIZE,
         max_workers=2,
         block_size=3,
-        block_capacity=3,
+        max_buffer_size=3 * 3,
         block_forward=2,
     ) as reader:  # buffer 最大为 6B
         assert reader._cached_blocks == []
 
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [1, 0]
+        assert reader._cached_blocks == [2, 1, 0]
 
         reader.seek(10)
         reader._buffer
         sleep_until_downloaded(reader)
-        assert reader._cached_blocks == [0, 4, 3]
+        assert reader._cached_blocks == [5, 4, 3]
 
 
 def test_http_prefetch_reader_read_with_forward_seek(http_patch):
@@ -455,7 +456,7 @@ def test_http_prefetch_reader_readinto(http_patch):
         content_size=CONTENT_SIZE,
         max_workers=2,
         block_size=3,
-        block_capacity=3,
+        max_buffer_size=3 * 3,
         block_forward=2,
     ) as reader:
         assert reader.readinto(bytearray(b"test")) == 4
@@ -465,7 +466,9 @@ def test_http_prefetch_reader_readinto(http_patch):
 
 
 def test_http_prefetch_reader_seek_history(http_patch):
-    with HttpPrefetchReader(URL, content_size=CONTENT_SIZE, block_capacity=3) as reader:
+    with HttpPrefetchReader(
+        URL, content_size=CONTENT_SIZE, max_buffer_size=3 * READER_BLOCK_SIZE
+    ) as reader:
         reader._seek_buffer(2)
         history = reader._seek_history[0]
         assert history.seek_count == 1

--- a/tests/lib/test_s3_buffered_writer.py
+++ b/tests/lib/test_s3_buffered_writer.py
@@ -53,7 +53,6 @@ def test_s3_buffered_writer_write_max_worker(client, mocker):
         s3_client=client,
         max_workers=2,
         block_size=8 * BACKOFF_INITIAL,
-        max_block_size=8 * BACKOFF_INITIAL,
     ) as writer:
         writer.write(content)
         writer.write(b"\n")
@@ -86,7 +85,7 @@ def test_s3_buffered_writer_write_large_bytes(client):
 
 
 def test_s3_buffered_writer_write_multipart(client, mocker):
-    block_size = 8 * 2**20
+    block_size = 10 * 2**20
     content_size = 16 * 2**20
     content = b"a" * content_size
 

--- a/tests/lib/test_s3_buffered_writer.py
+++ b/tests/lib/test_s3_buffered_writer.py
@@ -43,21 +43,19 @@ def test_s3_buffered_writer_write(client):
 
 
 def test_s3_buffered_writer_write_max_worker(client, mocker):
-    BACKOFF_INITIAL = 2**20
+    UNIT = 2**20
     content_size = 16 * 2**20
-    mocker.patch("megfile.lib.s3_buffered_writer.BACKOFF_INITIAL", BACKOFF_INITIAL)
     content = b"a" * content_size
     with S3BufferedWriter(
         BUCKET,
         KEY,
         s3_client=client,
         max_workers=2,
-        block_size=8 * BACKOFF_INITIAL,
+        block_size=8 * UNIT,
     ) as writer:
         writer.write(content)
         writer.write(b"\n")
         writer.write(content)
-        assert writer._backoff_size == BACKOFF_INITIAL * 4 * 4 * 4
 
     read_content = client.get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
     assert read_content == content + b"\n" + content

--- a/tests/lib/test_s3_buffered_writer.py
+++ b/tests/lib/test_s3_buffered_writer.py
@@ -141,7 +141,7 @@ def test_s3_buffered_writer_write_multipart_pending(client, mocker):
 
     def fake_wait(futures, **kwargs):
         if writer._buffer_size_before_wait is None:
-            writer._buffer_size_before_wait = writer._buffer_size
+            writer._buffer_size_before_wait = writer._total_buffer_size
         upload_part_event.set()
         return wait(futures, **kwargs)
 
@@ -156,15 +156,15 @@ def test_s3_buffered_writer_write_multipart_pending(client, mocker):
     writer.write(CONTENT)
     assert writer._buffer_size_before_wait == 22
     writer._buffer_size_before_wait = None
-    assert writer._buffer_size == 0
+    assert writer._total_buffer_size == 0
 
     writer.write(b"\n")
     assert writer._buffer_size_before_wait is None
-    assert writer._buffer_size == 0
+    assert writer._total_buffer_size == 0
 
     writer.write(CONTENT)
     assert writer._buffer_size_before_wait == 23
     writer._buffer_size_before_wait = None
-    assert writer._buffer_size == 0
+    assert writer._total_buffer_size == 0
 
     assert writer._is_multipart

--- a/tests/lib/test_s3_limited_seekable_writer.py
+++ b/tests/lib/test_s3_limited_seekable_writer.py
@@ -90,9 +90,7 @@ def test_write(client):
 
 
 def test_s3_buffered_writer_write_large_bytes(client):
-    with S3LimitedSeekableWriter(
-        BUCKET, KEY, s3_client=client, max_block_size=8
-    ) as writer:
+    with S3LimitedSeekableWriter(BUCKET, KEY, s3_client=client) as writer:
         writer.write(CONTENT * 10)
 
     with pytest.raises(IOError):

--- a/tests/lib/test_s3_prefetch_reader.py
+++ b/tests/lib/test_s3_prefetch_reader.py
@@ -121,7 +121,6 @@ def test_s3_prefetch_reader_read_readline_mix(s3_empty_client):
 
 
 def test_s3_prefetch_reader_seek_out_of_range(s3_empty_client, mocker):
-    mocker.patch("megfile.lib.base_prefetch_reader.BACKOFF_INITIAL", 4)
     s3_empty_client.create_bucket(Bucket=BUCKET)
     s3_empty_client.put_object(Bucket=BUCKET, Key=KEY, Body=b"1\n2\n3\n4\n")
     with S3PrefetchReader(
@@ -133,7 +132,6 @@ def test_s3_prefetch_reader_seek_out_of_range(s3_empty_client, mocker):
         reader.seek(100)
         assert reader.tell() == 8
         assert reader.read(2) == b""
-        assert reader._backoff_size == 16
 
         with pytest.raises(ValueError):
             reader.seek(0, "error_whence")

--- a/tests/lib/test_s3_prefetch_reader.py
+++ b/tests/lib/test_s3_prefetch_reader.py
@@ -274,6 +274,67 @@ def test_s3_prefetch_reader_backward_seek_and_the_target_in_remains(client, mock
         assert reader._cached_blocks == [2, 1, 0]
 
 
+def test_s3_prefetch_reader_max_buffer_size_eq_0(client, mocker):
+    """目标 offset 在 remains 中 重置 remains 位置"""
+    with S3PrefetchReader(
+        BUCKET,
+        KEY,
+        s3_client=client,
+        max_workers=2,
+        block_size=3,
+        max_buffer_size=0,
+    ) as reader:
+        assert reader._cached_blocks == []
+
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == []
+
+        reader.seek(3)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == []
+
+        reader.seek(1)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == []
+
+
+def test_s3_prefetch_reader_block_forward_eq_0(client, mocker):
+    """目标 offset 在 remains 中 重置 remains 位置"""
+    with S3PrefetchReader(
+        BUCKET,
+        KEY,
+        s3_client=client,
+        max_workers=2,
+        block_size=3,
+        max_buffer_size=3 * 2,
+        block_forward=0,
+    ) as reader:
+        assert reader._block_forward == 0
+        assert reader._cached_blocks == [0]
+
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == [0]
+
+        reader.seek(3)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == [0, 1]
+
+        reader.seek(9)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == [1, 3]
+
+        reader.seek(1)
+        reader._buffer
+        sleep_until_downloaded(reader)
+        assert reader._cached_blocks == [3, 0]
+
+
 def test_s3_prefetch_reader_backward_block_forward_eq_1(client, mocker):
     class FakeHistory:
         read_count = 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,7 +327,7 @@ def test_head_and_tail(runner, tmpdir, mocker):
     assert result.exit_code == 0
     assert result.output == "9\n"
 
-    mocker.patch("megfile.config.DEFAULT_BLOCK_SIZE", 1)
+    mocker.patch("megfile.config.READER_BLOCK_SIZE", 1)
     result = runner.invoke(tail, ["-n", "5", str(tmpdir / "text")])
 
     assert result.exit_code == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 
+import pytest
 from mock import patch
 
 
@@ -19,3 +20,29 @@ def test_config():
 
     assert config.READER_MAX_BUFFER_SIZE // 2**20 == 4 * 8
     assert config.WRITER_BLOCK_SIZE == 2**20
+
+
+@patch.dict(
+    os.environ,
+    {
+        "MEGFILE_READER_BLOCK_SIZE": "0",
+    },
+)
+def test_config_error():
+    with pytest.raises(ValueError):
+        from megfile import config
+
+        importlib.reload(config)
+
+
+@patch.dict(
+    os.environ,
+    {
+        "MEGFILE_WRITER_BLOCK_SIZE": "0",
+    },
+)
+def test_config_error2():
+    with pytest.raises(ValueError):
+        from megfile import config
+
+        importlib.reload(config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,9 +7,8 @@ from mock import patch
 @patch.dict(
     os.environ,
     {
-        "MEGFILE_MAX_BUFFER_SIZE": str(4 * 8 * 2**20),
-        "MEGFILE_BLOCK_CAPACITY": "20",
-        "MEGFILE_MAX_BLOCK_SIZE": str(2**20),
+        "MEGFILE_READER_MAX_BUFFER_SIZE": str(4 * 8 * 2**20),
+        "MEGFILE_WRITER_BLOCK_SIZE": str(2**20),
         "AWS_SECRET_ACCESS_KEY": "test",
     },
 )
@@ -18,16 +17,5 @@ def test_config():
 
     importlib.reload(config)
 
-    assert config.DEFAULT_MAX_BUFFER_SIZE // 2**20 == 4 * 8
-    assert config.DEFAULT_BLOCK_CAPACITY == 4
-    assert config.DEFAULT_MAX_BLOCK_SIZE == config.DEFAULT_BLOCK_SIZE
-
-
-@patch.dict(os.environ, {"MEGFILE_BLOCK_CAPACITY": "20"})
-def test_config_only_capacity():
-    from megfile import config
-
-    importlib.reload(config)
-
-    assert config.DEFAULT_MAX_BUFFER_SIZE // 2**20 == 20 * 8
-    assert config.DEFAULT_BLOCK_CAPACITY == 20
+    assert config.READER_MAX_BUFFER_SIZE // 2**20 == 4 * 8
+    assert config.WRITER_BLOCK_SIZE == 2**20

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -234,7 +234,7 @@ def test_http_getstat(mocker):
 
 def test_get_http_session(mocker):
     requests_request_func = mocker.patch("requests.Session.request")
-    mocker.patch("megfile.http_path.max_retries", 1)
+    mocker.patch("megfile.http_path.HTTP_MAX_RETRY_TIMES", 1)
 
     class FakeResponse502(FakeResponse):
         status_code = 502

--- a/tests/test_http_purepath.py
+++ b/tests/test_http_purepath.py
@@ -278,7 +278,7 @@ def test_with_suffix():
 
 def test_http_retry(requests_mock, mocker):
     max_retries = 2
-    mocker.patch("megfile.http_path.max_retries", max_retries)
+    mocker.patch("megfile.http_path.HTTP_MAX_RETRY_TIMES", max_retries)
     requests_mock.post("http://foo", status_code=500)
     session = get_http_session()
     history_index = 0

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -2748,9 +2748,7 @@ def test_s3_prefetch_open(s3_empty_client):
         assert reader.mode == "rb"
         assert reader.read() == content
 
-    with s3.s3_prefetch_open(
-        "s3://bucket/key", max_concurrency=1, block_size=1
-    ) as reader:
+    with s3.s3_prefetch_open("s3://bucket/key", max_workers=1, block_size=1) as reader:
         assert reader.read() == content
 
     with s3.s3_prefetch_open("s3://bucket/symlink", followlinks=True) as reader:
@@ -2759,12 +2757,12 @@ def test_s3_prefetch_open(s3_empty_client):
         assert reader.read() == content
 
     with s3.s3_prefetch_open(
-        "s3://bucket/symlink", max_concurrency=1, block_size=1, followlinks=True
+        "s3://bucket/symlink", max_workers=1, block_size=1, followlinks=True
     ) as reader:
         assert reader.read() == content
 
     with pytest.raises(S3BucketNotFoundError):
-        s3.s3_prefetch_open("s3://", max_concurrency=1, block_size=1)
+        s3.s3_prefetch_open("s3://", max_workers=1, block_size=1)
 
     with pytest.raises(ValueError):
         s3.s3_prefetch_open("s3://bucket/key", mode="wb")
@@ -2786,9 +2784,7 @@ def test_s3_share_cache_open(s3_empty_client):
         assert reader.mode == "rb"
         assert reader.read() == content
 
-    with s3.s3_prefetch_open(
-        "s3://bucket/key", max_concurrency=1, block_size=1
-    ) as reader:
+    with s3.s3_prefetch_open("s3://bucket/key", max_workers=1, block_size=1) as reader:
         assert reader.read() == content
 
     with s3.s3_share_cache_open("s3://bucket/symlink", followlinks=True) as reader:
@@ -2797,7 +2793,7 @@ def test_s3_share_cache_open(s3_empty_client):
         assert reader.read() == content
 
     with s3.s3_prefetch_open(
-        "s3://bucket/symlink", max_concurrency=1, block_size=1, followlinks=True
+        "s3://bucket/symlink", max_workers=1, block_size=1, followlinks=True
     ) as reader:
         assert reader.read() == content
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -19,8 +19,6 @@ from moto import mock_aws
 
 from megfile import s3, s3_path, smart
 from megfile.config import (
-    DEFAULT_BLOCK_SIZE,
-    DEFAULT_MAX_BUFFER_SIZE,
     GLOBAL_MAX_WORKERS,
 )
 from megfile.errors import (
@@ -2751,7 +2749,7 @@ def test_s3_prefetch_open(s3_empty_client):
         assert reader.read() == content
 
     with s3.s3_prefetch_open(
-        "s3://bucket/key", max_concurrency=1, max_block_size=1
+        "s3://bucket/key", max_concurrency=1, block_size=1
     ) as reader:
         assert reader.read() == content
 
@@ -2761,12 +2759,12 @@ def test_s3_prefetch_open(s3_empty_client):
         assert reader.read() == content
 
     with s3.s3_prefetch_open(
-        "s3://bucket/symlink", max_concurrency=1, max_block_size=1, followlinks=True
+        "s3://bucket/symlink", max_concurrency=1, block_size=1, followlinks=True
     ) as reader:
         assert reader.read() == content
 
     with pytest.raises(S3BucketNotFoundError):
-        s3.s3_prefetch_open("s3://", max_concurrency=1, max_block_size=1)
+        s3.s3_prefetch_open("s3://", max_concurrency=1, block_size=1)
 
     with pytest.raises(ValueError):
         s3.s3_prefetch_open("s3://bucket/key", mode="wb")
@@ -2789,7 +2787,7 @@ def test_s3_share_cache_open(s3_empty_client):
         assert reader.read() == content
 
     with s3.s3_prefetch_open(
-        "s3://bucket/key", max_concurrency=1, max_block_size=1
+        "s3://bucket/key", max_concurrency=1, block_size=1
     ) as reader:
         assert reader.read() == content
 
@@ -2799,7 +2797,7 @@ def test_s3_share_cache_open(s3_empty_client):
         assert reader.read() == content
 
     with s3.s3_prefetch_open(
-        "s3://bucket/symlink", max_concurrency=1, max_block_size=1, followlinks=True
+        "s3://bucket/symlink", max_concurrency=1, block_size=1, followlinks=True
     ) as reader:
         assert reader.read() == content
 
@@ -2983,9 +2981,9 @@ def test_s3_buffered_open(mocker, s3_empty_client, fs):
     assert isinstance(reader, BufferedReader)
 
     s3_empty_client.put_object(Bucket="bucket", Key="key", Body=content)
-    reader = s3.s3_buffered_open("s3://bucket/key", "rb", forward_ratio=0.5)
+    reader = s3.s3_buffered_open("s3://bucket/key", "rb", block_forward=1)
     assert isinstance(reader, s3_path.S3PrefetchReader)
-    assert reader._block_forward == DEFAULT_MAX_BUFFER_SIZE // DEFAULT_BLOCK_SIZE * 0.5
+    assert reader._block_forward == 1
 
     reader = s3.s3_buffered_open("s3://bucket/key", "rb", share_cache_key="share")
     assert isinstance(reader, s3_path.S3ShareCacheReader)

--- a/tests/test_smart_purepath.py
+++ b/tests/test_smart_purepath.py
@@ -104,10 +104,6 @@ def test_operators():
     assert SmartPath("foo") / "bar" / "baz" == SmartPath("foo/bar/baz")
     assert SmartPath("file://foo") / "bar" / "baz" in {SmartPath("file://foo/bar/baz")}
 
-    # TODO: 下面是还暂不支持的用法
-    # assert 'file://foo' / SmartPath('bar') == SmartPath('file://foo/bar')
-    # assert 'foo' / SmartPath('bar') == SmartPath('foo/bar')
-
 
 def test_parts():
     assert SmartPath("file://foo//bar").parts == ("foo", "bar")


### PR DESCRIPTION
- change some environments
    - remove `MEGFILE_BLOCK_SIZE`, `MEGFILE_MAX_BUFFER_SIZE`, `MEGFILE_BLOCK_CAPACITY`, `MEGFILE_MIN_BLOCK_SIZE`, `MEGFILE_MAX_BLOCK_SIZE`
    - add `MEGFILE_READER_BLOCK_SIZE`, `MEGFILE_READER_MAX_BUFFER_SIZE`, `MEGFILE_WRITER_BLOCK_SIZE`, `MEGFILE_WRITER_MAX_BUFFER_SIZE`
    - `MEGFILE_MAX_WORKERS` default value changed from `32` to `8`
- change all open method's params
    - remove `min_block_size` and `max_block_size`
    - `forward_ratio: Optional[float]` -> `block_forward: Optional[int]`
    - `max_concurrency` -> `max_workers`
- change all `PrefetchReader.__init__` params
    - `block_capacity: int` -> `max_buffer_size: int`
- change `S3BufferedWriter.__init__` params
    - remove `max_block_size`