### PR TITLE
feat: s3 buffered writer block size autoscale

### DIFF
--- a/megfile/config.py
+++ b/megfile/config.py
@@ -43,10 +43,10 @@ if "MEGFILE_MAX_BLOCK_SIZE" in os.environ:
 else:
     DEFAULT_MAX_BLOCK_SIZE = max(128 * 2**20, DEFAULT_BLOCK_SIZE)
 
-if "MEGFILE_BLOCK_AOTOSCALE" in os.environ:
-    DEFAULT_BLOCK_AOTOSCALE = to_boolean(os.environ["MEGFILE_BLOCK_AOTOSCALE"].lower())
+if "DEFAULT_BLOCK_AUTOSCALE" in os.environ:
+    DEFAULT_BLOCK_AUTOSCALE = to_boolean(os.environ["DEFAULT_BLOCK_AUTOSCALE"].lower())
 else:
-    DEFAULT_BLOCK_AOTOSCALE = (
+    DEFAULT_BLOCK_AUTOSCALE = (
         "MEGFILE_BLOCK_SIZE" not in os.environ
         and "MEGFILE_MAX_BLOCK_SIZE" not in os.environ
         and "MEGFILE_MIN_BLOCK_SIZE" not in os.environ

--- a/megfile/config.py
+++ b/megfile/config.py
@@ -3,9 +3,14 @@ from logging import getLogger
 
 _logger = getLogger(__name__)
 
+
+def to_boolean(value):
+    return value.lower() in ("true", "yes", "1")
+
+
 DEFAULT_BLOCK_SIZE = int(os.getenv("MEGFILE_BLOCK_SIZE") or 8 * 2**20)
 
-if os.getenv("MEGFILE_MAX_BUFFER_SIZE"):
+if "MEGFILE_MAX_BUFFER_SIZE" in os.environ:
     DEFAULT_MAX_BUFFER_SIZE = int(os.environ["MEGFILE_MAX_BUFFER_SIZE"])
     if DEFAULT_MAX_BUFFER_SIZE < DEFAULT_BLOCK_SIZE:
         DEFAULT_MAX_BUFFER_SIZE = DEFAULT_BLOCK_SIZE
@@ -14,12 +19,12 @@ if os.getenv("MEGFILE_MAX_BUFFER_SIZE"):
             "will not use buffer."
         )
     DEFAULT_BLOCK_CAPACITY = DEFAULT_MAX_BUFFER_SIZE // DEFAULT_BLOCK_SIZE
-    if os.getenv("MEGFILE_BLOCK_CAPACITY"):
+    if "MEGFILE_BLOCK_CAPACITY" in os.environ:
         _logger.warning(
             "Env 'MEGFILE_MAX_BUFFER_SIZE' and 'MEGFILE_BLOCK_CAPACITY' are both set, "
             "'MEGFILE_BLOCK_CAPACITY' will be ignored."
         )
-elif os.getenv("MEGFILE_BLOCK_CAPACITY"):
+elif "MEGFILE_BLOCK_CAPACITY" in os.environ:
     DEFAULT_BLOCK_CAPACITY = int(os.environ["MEGFILE_BLOCK_CAPACITY"])
     DEFAULT_MAX_BUFFER_SIZE = DEFAULT_BLOCK_SIZE * DEFAULT_BLOCK_CAPACITY
 else:
@@ -28,7 +33,7 @@ else:
 
 DEFAULT_MIN_BLOCK_SIZE = int(os.getenv("MEGFILE_MIN_BLOCK_SIZE") or DEFAULT_BLOCK_SIZE)
 
-if os.getenv("MEGFILE_MAX_BLOCK_SIZE"):
+if "MEGFILE_MAX_BLOCK_SIZE" in os.environ:
     DEFAULT_MAX_BLOCK_SIZE = int(os.environ["MEGFILE_MAX_BLOCK_SIZE"])
     if DEFAULT_MAX_BLOCK_SIZE < DEFAULT_BLOCK_SIZE:
         DEFAULT_MAX_BLOCK_SIZE = DEFAULT_BLOCK_SIZE
@@ -37,6 +42,15 @@ if os.getenv("MEGFILE_MAX_BLOCK_SIZE"):
         )
 else:
     DEFAULT_MAX_BLOCK_SIZE = max(128 * 2**20, DEFAULT_BLOCK_SIZE)
+
+if "MEGFILE_BLOCK_AOTOSCALE" in os.environ:
+    DEFAULT_BLOCK_AOTOSCALE = to_boolean(os.environ["MEGFILE_BLOCK_AOTOSCALE"].lower())
+else:
+    DEFAULT_BLOCK_AOTOSCALE = (
+        "MEGFILE_BLOCK_SIZE" not in os.environ
+        and "MEGFILE_MAX_BLOCK_SIZE" not in os.environ
+        and "MEGFILE_MIN_BLOCK_SIZE" not in os.environ
+    )
 
 GLOBAL_MAX_WORKERS = int(os.getenv("MEGFILE_MAX_WORKERS") or 32)
 DEFAULT_MAX_RETRY_TIMES = int(os.getenv("MEGFILE_MAX_RETRY_TIMES") or 10)

--- a/megfile/config.py
+++ b/megfile/config.py
@@ -10,7 +10,7 @@ def to_boolean(value):
 
 DEFAULT_BLOCK_SIZE = int(os.getenv("MEGFILE_BLOCK_SIZE") or 8 * 2**20)
 
-if "MEGFILE_MAX_BUFFER_SIZE" in os.environ:
+if os.getenv("MEGFILE_MAX_BUFFER_SIZE"):
     DEFAULT_MAX_BUFFER_SIZE = int(os.environ["MEGFILE_MAX_BUFFER_SIZE"])
     if DEFAULT_MAX_BUFFER_SIZE < DEFAULT_BLOCK_SIZE:
         DEFAULT_MAX_BUFFER_SIZE = DEFAULT_BLOCK_SIZE
@@ -19,12 +19,12 @@ if "MEGFILE_MAX_BUFFER_SIZE" in os.environ:
             "will not use buffer."
         )
     DEFAULT_BLOCK_CAPACITY = DEFAULT_MAX_BUFFER_SIZE // DEFAULT_BLOCK_SIZE
-    if "MEGFILE_BLOCK_CAPACITY" in os.environ:
+    if os.getenv("MEGFILE_BLOCK_CAPACITY"):
         _logger.warning(
             "Env 'MEGFILE_MAX_BUFFER_SIZE' and 'MEGFILE_BLOCK_CAPACITY' are both set, "
             "'MEGFILE_BLOCK_CAPACITY' will be ignored."
         )
-elif "MEGFILE_BLOCK_CAPACITY" in os.environ:
+elif os.getenv("MEGFILE_BLOCK_CAPACITY"):
     DEFAULT_BLOCK_CAPACITY = int(os.environ["MEGFILE_BLOCK_CAPACITY"])
     DEFAULT_MAX_BUFFER_SIZE = DEFAULT_BLOCK_SIZE * DEFAULT_BLOCK_CAPACITY
 else:
@@ -33,7 +33,7 @@ else:
 
 DEFAULT_MIN_BLOCK_SIZE = int(os.getenv("MEGFILE_MIN_BLOCK_SIZE") or DEFAULT_BLOCK_SIZE)
 
-if "MEGFILE_MAX_BLOCK_SIZE" in os.environ:
+if os.getenv("MEGFILE_MAX_BLOCK_SIZE"):
     DEFAULT_MAX_BLOCK_SIZE = int(os.environ["MEGFILE_MAX_BLOCK_SIZE"])
     if DEFAULT_MAX_BLOCK_SIZE < DEFAULT_BLOCK_SIZE:
         DEFAULT_MAX_BLOCK_SIZE = DEFAULT_BLOCK_SIZE
@@ -43,13 +43,13 @@ if "MEGFILE_MAX_BLOCK_SIZE" in os.environ:
 else:
     DEFAULT_MAX_BLOCK_SIZE = max(128 * 2**20, DEFAULT_BLOCK_SIZE)
 
-if "MEGFILE_BLOCK_AUTOSCALE" in os.environ:
+if os.getenv("MEGFILE_BLOCK_AUTOSCALE"):
     DEFAULT_BLOCK_AUTOSCALE = to_boolean(os.environ["MEGFILE_BLOCK_AUTOSCALE"].lower())
 else:
     DEFAULT_BLOCK_AUTOSCALE = (
-        "MEGFILE_BLOCK_SIZE" not in os.environ
-        and "MEGFILE_MAX_BLOCK_SIZE" not in os.environ
-        and "MEGFILE_MIN_BLOCK_SIZE" not in os.environ
+        not os.getenv("MEGFILE_BLOCK_SIZE")
+        and not os.getenv("MEGFILE_MAX_BLOCK_SIZE")
+        and not os.getenv("MEGFILE_MIN_BLOCK_SIZE")
     )
 
 GLOBAL_MAX_WORKERS = int(os.getenv("MEGFILE_MAX_WORKERS") or 32)

--- a/megfile/config.py
+++ b/megfile/config.py
@@ -43,8 +43,8 @@ if "MEGFILE_MAX_BLOCK_SIZE" in os.environ:
 else:
     DEFAULT_MAX_BLOCK_SIZE = max(128 * 2**20, DEFAULT_BLOCK_SIZE)
 
-if "DEFAULT_BLOCK_AUTOSCALE" in os.environ:
-    DEFAULT_BLOCK_AUTOSCALE = to_boolean(os.environ["DEFAULT_BLOCK_AUTOSCALE"].lower())
+if "MEGFILE_BLOCK_AUTOSCALE" in os.environ:
+    DEFAULT_BLOCK_AUTOSCALE = to_boolean(os.environ["MEGFILE_BLOCK_AUTOSCALE"].lower())
 else:
     DEFAULT_BLOCK_AUTOSCALE = (
         "MEGFILE_BLOCK_SIZE" not in os.environ

--- a/megfile/lib/s3_buffered_writer.py
+++ b/megfile/lib/s3_buffered_writer.py
@@ -8,7 +8,7 @@ from typing import NamedTuple, Optional
 from megfile.config import (
     BACKOFF_FACTOR,
     BACKOFF_INITIAL,
-    DEFAULT_BLOCK_AOTOSCALE,
+    DEFAULT_BLOCK_AUTOSCALE,
     DEFAULT_MAX_BLOCK_SIZE,
     DEFAULT_MAX_BUFFER_SIZE,
     DEFAULT_MIN_BLOCK_SIZE,
@@ -47,7 +47,7 @@ class S3BufferedWriter(Writable[bytes]):
         *,
         s3_client,
         block_size: int = DEFAULT_MIN_BLOCK_SIZE,
-        block_autoscale: bool = DEFAULT_BLOCK_AOTOSCALE,
+        block_autoscale: bool = DEFAULT_BLOCK_AUTOSCALE,
         max_block_size: int = DEFAULT_MAX_BLOCK_SIZE,
         max_buffer_size: int = DEFAULT_MAX_BUFFER_SIZE,
         max_workers: Optional[int] = None,

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -21,6 +21,7 @@ from megfile.config import (
     HTTP_AUTH_HEADERS,
     S3_CLIENT_CACHE_MODE,
     S3_MAX_RETRY_TIMES,
+    to_boolean,
 )
 from megfile.errors import (
     S3BucketNotFoundError,
@@ -266,7 +267,7 @@ def get_env_var(env_name: str, profile_name=None):
 def parse_boolean(value: Optional[str], default: bool = False) -> bool:
     if value is None:
         return default
-    return value.lower() in ("true", "yes", "1")
+    return to_boolean(value)
 
 
 def get_access_token(profile_name=None):

--- a/tests/lib/test_s3_buffered_writer.py
+++ b/tests/lib/test_s3_buffered_writer.py
@@ -169,3 +169,39 @@ def test_s3_buffered_writer_write_multipart_pending(client, mocker):
     assert writer._buffer_size == 0
 
     assert writer._is_multipart
+
+
+def test_s3_buffered_writer_write_multipart_autoscale(client, mocker):
+    block_size = 8 * 2**20
+    content_size = 8 * 2**20
+    content_repeat = 20
+    content = b"a" * content_size
+
+    put_object_func = mocker.spy(client, "put_object")
+    create_multipart_upload_func = mocker.spy(client, "create_multipart_upload")
+    upload_part_func = mocker.spy(client, "upload_part")
+    complete_multipart_upload_func = mocker.spy(client, "complete_multipart_upload")
+
+    with S3BufferedWriter(
+        BUCKET, KEY, s3_client=client, block_size=block_size
+    ) as writer:
+        for _ in range(content_repeat):
+            writer.write(content)
+            writer.write(b"\n")
+
+    assert writer._is_multipart
+    # put_object_func.assert_not_called() in Python 3.6+
+    assert put_object_func.call_count == 0
+    create_multipart_upload_func.assert_called_once_with(Bucket=BUCKET, Key=KEY)
+
+    assert upload_part_func.call_count == 16
+
+    complete_multipart_upload_func.assert_called_once_with(
+        Bucket=BUCKET,
+        Key=KEY,
+        UploadId=writer._upload_id,
+        MultipartUpload=writer._multipart_upload,
+    )
+
+    content_read = client.get_object(Bucket=BUCKET, Key=KEY)["Body"].read()
+    assert content_read == (content + b"\n") * content_repeat


### PR DESCRIPTION
megfile 写入大文件时会吃到

```
megfile.errors.S3UnknownError: Unknown error encountered: 's3://...', error: botocore.exceptions.ClientError('An err
or occurred (InvalidArgument) when calling the UploadPart operation: Part number must be an integer between
 1 and 10000, inclusive.'), endpoint: 'https://oss-cn-beijing-internal.aliyuncs.com'
```

报错，而 fsspec 默认 block size = 50MB 则几乎不会遇到这个问题

为了保证 megfile 写入小文件时依然可以使用较大并发产生速度优势，并可以写入大文件，设计了一种阶梯上升的 block size，在写入 10 / 100 / 1000 / 10000 块时 block size 翻倍，这样在 10000 part number 限制下最大能上传 600GB 左右的文件