### PR TITLE
Fix `KeyError` crash when etag is not returned

### DIFF
--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -120,7 +120,7 @@ class S3PrefetchReader(BasePrefetchReader):
         start, end = index * self._block_size, (index + 1) * self._block_size - 1
         response = self._fetch_response(start=start, end=end)
         etag = response.get("ETag", None)
-        if etag is not None and etag != self._content_etag:
+        if self._content_etag and etag and etag != self._content_etag:
             raise S3FileChangedError(
                 "File changed: %r, etag before: %s, after: %s"
                 % (self.name, self._content_etag, etag)

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -64,7 +64,7 @@ class S3PrefetchReader(BasePrefetchReader):
     def _get_content_size(self):
         if self._block_capacity <= 0:
             response = self._client.head_object(Bucket=self._bucket, Key=self._key)
-            self._content_etag = response["ETag"]
+            self._content_etag = response.get("ETag")
             return int(response["ContentLength"])
 
         try:
@@ -84,7 +84,7 @@ class S3PrefetchReader(BasePrefetchReader):
         first_future = Future()
         first_future.set_result(first_index_response["Body"])
         self._insert_futures(index=0, future=first_future)
-        self._content_etag = first_index_response["ETag"]
+        self._content_etag = first_index_response.get('ETag')
         return content_size
 
     @property

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -84,7 +84,7 @@ class S3PrefetchReader(BasePrefetchReader):
         first_future = Future()
         first_future.set_result(first_index_response["Body"])
         self._insert_futures(index=0, future=first_future)
-        self._content_etag = first_index_response.get('ETag')
+        self._content_etag = first_index_response.get("ETag")
         return content_size
 
     @property


### PR DESCRIPTION
When etag is not returned by s3 server, megfile crashes with `[KeyError] 'ETag's]`. We should be able to handle those cases.