### PR TITLE
refactor:remove missing_ok and follow_links in listdir and iterdir

### DIFF
--- a/megfile/errors.py
+++ b/megfile/errors.py
@@ -413,12 +413,12 @@ def translate_http_error(http_error: Exception, http_url: str) -> Exception:
 
 
 @contextmanager
-def raise_s3_error(s3_url: PathLike, suppress_errors=()):
+def raise_s3_error(s3_url: PathLike, suppress_error_callback=None):
     try:
         yield
     except Exception as error:
         error = translate_s3_error(error, s3_url)
-        if suppress_errors and isinstance(error, suppress_errors):
+        if suppress_error_callback and suppress_error_callback(error):
             return
         raise error
 

--- a/megfile/fs.py
+++ b/megfile/fs.py
@@ -317,13 +317,13 @@ def fs_walk(
     return FSPath(path).walk(followlinks)
 
 
-def fs_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = True):
+def fs_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = False):
     """
     Calculate the md5 value of the file
 
     :param path: Given path
     :param recalculate: Ignore this parameter, just for compatibility
-    :param followlinks: Ignore this parameter, just for compatibility
+    :param followlinks: If is True, calculate md5 for real file
 
     returns: md5 of file
     """

--- a/megfile/fs.py
+++ b/megfile/fs.py
@@ -323,7 +323,7 @@ def fs_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = Fal
 
     :param path: Given path
     :param recalculate: Ignore this parameter, just for compatibility
-    :param followlinks: If is True, calculate md5 for real file
+    :param followlinks: Ignore this parameter, just for compatibility
 
     returns: md5 of file
     """

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -706,20 +706,23 @@ class FSPath(URIPath):
             )
         )
 
-    def md5(self, recalculate: bool = False, followlinks: bool = False):
+    def md5(self, recalculate: bool = False, followlinks: bool = True):
         """
         Calculate the md5 value of the file
 
         :param recalculate: Ignore this parameter, just for compatibility
-        :param followlinks: Ignore this parameter, just for compatibility
+        :param followlinks: If is True, calculate md5 for real file
 
         returns: md5 of file
         """
-        if os.path.isdir(self.path_without_protocol):
+        stat = self.stat(follow_symlinks=False)
+        if followlinks and stat.is_symlink():
+            return self.readlink().md5(recalculate=recalculate, followlinks=followlinks)
+        elif stat.is_dir():
             hash_md5 = hashlib.md5()  # nosec
             for file_name in self.listdir():
                 chunk = (
-                    FSPath(self.path_without_protocol, file_name)
+                    self.joinpath(file_name)
                     .md5(recalculate=recalculate, followlinks=followlinks)
                     .encode()
                 )

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -397,7 +397,9 @@ class FSPath(URIPath):
         :returns: All contents have in the path.
         """
         self._check_int_path()
-        for path in pathlib.Path(self.path_without_protocol).iterdir():
+        for path in pathlib.Path(
+            self.path_without_protocol  # pyre-ignore[6]
+        ).iterdir():
             yield self.from_path(fspath(path))
 
     def load(self) -> BinaryIO:

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -570,7 +570,7 @@ class FSPath(URIPath):
                 "No match any file in: %r" % self.path_without_protocol
             )
 
-    def scandir(self) -> Iterator[FileEntry]:
+    def scandir(self) -> ContextIterator:
         """
         Get all content of given file path.
 

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -706,7 +706,7 @@ class FSPath(URIPath):
             )
         )
 
-    def md5(self, recalculate: bool = False, followlinks: bool = True):
+    def md5(self, recalculate: bool = False, followlinks: bool = False):
         """
         Calculate the md5 value of the file
 

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -706,19 +706,16 @@ class FSPath(URIPath):
             )
         )
 
-    def md5(self, recalculate: bool = False, followlinks: bool = True):
+    def md5(self, recalculate: bool = False, followlinks: bool = False):
         """
         Calculate the md5 value of the file
 
         :param recalculate: Ignore this parameter, just for compatibility
-        :param followlinks: If is True, calculate md5 for real file
+        :param followlinks: Ignore this parameter, just for compatibility
 
         returns: md5 of file
         """
-        stat = self.stat(follow_symlinks=False)
-        if followlinks and stat.is_symlink():
-            return self.readlink().md5(recalculate=recalculate, followlinks=followlinks)
-        elif stat.is_dir():
+        if self.is_dir():
             hash_md5 = hashlib.md5()  # nosec
             for file_name in self.listdir():
                 chunk = (

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -388,17 +388,21 @@ class FSPath(URIPath):
         :returns: All contents have in the path in ascending alphabetical order
         """
         self._check_int_path()
+        if not self.exists():
+            raise FileNotFoundError("No such directory: %r" % self.path)
+        elif not self.is_dir():
+            raise NotADirectoryError("Not a directory: %r" % self.path)
         return sorted(os.listdir(self.path_without_protocol))  # pyre-ignore[6]
 
     def iterdir(self) -> Iterator["FSPath"]:
         """
-        Get all contents of given fs path.
-        The result is in ascending alphabetical order.
+        Get all contents of given fs path. The order of result is in arbitrary order..
 
-        :returns: All contents have in the path in ascending alphabetical order
+        :returns: All contents have in the path.
         """
-        for path in self.listdir():
-            yield self.joinpath(path)
+        self._check_int_path()
+        for path in pathlib.Path(self.path_without_protocol).iterdir():
+            yield self.from_path(fspath(path))
 
     def load(self) -> BinaryIO:
         """Read all content on specified path and write into memory

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -392,7 +392,7 @@ class FSPath(URIPath):
 
     def iterdir(self) -> Iterator["FSPath"]:
         """
-        Get all contents of given fs path. The order of result is in arbitrary order..
+        Get all contents of given fs path. The order of result is in arbitrary order.
 
         :returns: All contents have in the path.
         """

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -388,10 +388,6 @@ class FSPath(URIPath):
         :returns: All contents have in the path in ascending alphabetical order
         """
         self._check_int_path()
-        if not self.exists():
-            raise FileNotFoundError("No such directory: %r" % self.path)
-        elif not self.is_dir():
-            raise NotADirectoryError("Not a directory: %r" % self.path)
         return sorted(os.listdir(self.path_without_protocol))  # pyre-ignore[6]
 
     def iterdir(self) -> Iterator["FSPath"]:

--- a/megfile/hdfs.py
+++ b/megfile/hdfs.py
@@ -211,7 +211,7 @@ def hdfs_scan_stat(
 
 def hdfs_scandir(path: PathLike, followlinks: bool = False) -> Iterator[FileEntry]:
     """
-    Get all contents of given path, the order of result is in arbitrary order..
+    Get all contents of given path, the order of result is in arbitrary order.
 
     :param path: Given path
     :returns: All contents have prefix of path

--- a/megfile/hdfs.py
+++ b/megfile/hdfs.py
@@ -125,7 +125,7 @@ def hdfs_isfile(path: PathLike, followlinks: bool = False) -> bool:
     return HdfsPath(path).is_file(followlinks)
 
 
-def hdfs_listdir(path: PathLike, followlinks: bool = False) -> List[str]:
+def hdfs_listdir(path: PathLike) -> List[str]:
     """
     Get all contents of given path.
 
@@ -133,7 +133,7 @@ def hdfs_listdir(path: PathLike, followlinks: bool = False) -> List[str]:
     :returns: All contents have prefix of path.
     :raises: FileNotFoundError, NotADirectoryError
     """
-    return HdfsPath(path).listdir(followlinks)
+    return HdfsPath(path).listdir()
 
 
 def hdfs_load_from(path: PathLike, followlinks: bool = False) -> BinaryIO:
@@ -211,7 +211,7 @@ def hdfs_scan_stat(
 
 def hdfs_scandir(path: PathLike, followlinks: bool = False) -> Iterator[FileEntry]:
     """
-    Get all contents of given path, the order of result is not guaranteed.
+    Get all contents of given path, the order of result is in arbitrary order..
 
     :param path: Given path
     :returns: All contents have prefix of path

--- a/megfile/hdfs.py
+++ b/megfile/hdfs.py
@@ -136,7 +136,7 @@ def hdfs_listdir(path: PathLike) -> List[str]:
     return HdfsPath(path).listdir()
 
 
-def hdfs_load_from(path: PathLike, followlinks: bool = False) -> BinaryIO:
+def hdfs_load_from(path: PathLike) -> BinaryIO:
     """Read all content in binary on specified path and write into memory
 
     User should close the BinaryIO manually
@@ -144,7 +144,7 @@ def hdfs_load_from(path: PathLike, followlinks: bool = False) -> BinaryIO:
     :param path: Given path
     :returns: BinaryIO
     """
-    return HdfsPath(path).load(followlinks)
+    return HdfsPath(path).load()
 
 
 def hdfs_move(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) -> None:
@@ -209,7 +209,7 @@ def hdfs_scan_stat(
     return HdfsPath(path).scan_stat(missing_ok, followlinks)
 
 
-def hdfs_scandir(path: PathLike, followlinks: bool = False) -> Iterator[FileEntry]:
+def hdfs_scandir(path: PathLike) -> Iterator[FileEntry]:
     """
     Get all contents of given path, the order of result is in arbitrary order.
 
@@ -217,7 +217,7 @@ def hdfs_scandir(path: PathLike, followlinks: bool = False) -> Iterator[FileEntr
     :returns: All contents have prefix of path
     :raises: FileNotFoundError, NotADirectoryError
     """
-    return HdfsPath(path).scandir(followlinks)
+    return HdfsPath(path).scandir()
 
 
 def hdfs_unlink(path: PathLike, missing_ok: bool = False) -> None:

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -326,7 +326,7 @@ class HdfsPath(URIPath):
         :returns: All contents have prefix of path.
         :raises: FileNotFoundError, NotADirectoryError
         """
-        if not self.stat().is_dir():
+        if not self.is_dir():
             raise NotADirectoryError("Not a directory: %r" % self.path)
         with raise_hdfs_error(self.path_with_protocol):
             return sorted(self._client.list(self.path_without_protocol))

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -547,7 +547,7 @@ class HdfsPath(URIPath):
             ):
                 yield f"{self._protocol_with_profile}://{path.lstrip('/')}", dirs, files
 
-    def md5(self, recalculate: bool = False, followlinks: bool = True) -> str:
+    def md5(self, recalculate: bool = False, followlinks: bool = False) -> str:
         """
         Get checksum of the file or dir.
 

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -341,7 +341,7 @@ class HdfsPath(URIPath):
         for filename in self.listdir():
             yield self.joinpath(filename)
 
-    def load(self, followlinks: bool = False) -> BinaryIO:
+    def load(self) -> BinaryIO:
         """Read all content in binary on specified path and write into memory
 
         User should close the BinaryIO manually
@@ -476,7 +476,7 @@ class HdfsPath(URIPath):
                         ),
                     )
 
-    def scandir(self, followlinks: bool = False) -> Iterator[FileEntry]:
+    def scandir(self) -> Iterator[FileEntry]:
         """
         Get all contents of given path, the order of result is in arbitrary order.
 

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -547,7 +547,7 @@ class HdfsPath(URIPath):
             ):
                 yield f"{self._protocol_with_profile}://{path.lstrip('/')}", dirs, files
 
-    def md5(self, recalculate: bool = False, followlinks: bool = False) -> str:
+    def md5(self, recalculate: bool = False, followlinks: bool = True) -> str:
         """
         Get checksum of the file or dir.
 

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -478,7 +478,7 @@ class HdfsPath(URIPath):
 
     def scandir(self, followlinks: bool = False) -> Iterator[FileEntry]:
         """
-        Get all contents of given path, the order of result is in arbitrary order..
+        Get all contents of given path, the order of result is in arbitrary order.
 
         :returns: All contents have prefix of path
         :raises: FileNotFoundError, NotADirectoryError

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -412,7 +412,7 @@ class BasePath:
         raw_suffix = self.suffix
         return self.from_path(path[: len(path) - len(raw_suffix)] + suffix)
 
-    def relpath(self, start=None):
+    def relpath(self, start: Optional[str] = None):
         """Return the relative path."""
         if start is None:
             raise TypeError("start is required")
@@ -485,7 +485,7 @@ class BasePath:
         """Return the canonical path of the path."""
         return self.path_with_protocol
 
-    def resolve(self):
+    def resolve(self, strict=False):
         """Alias of realpath."""
         return self.path_with_protocol
 
@@ -622,11 +622,11 @@ class BasePath:
         """
         raise NotImplementedError('method "scandir" not implemented: %r' % self)
 
-    def getsize(self, follow_symlinks: bool = True) -> int:
+    def getsize(self, follow_symlinks: bool = False) -> int:
         """Return the size, in bytes."""
         raise NotImplementedError('method "getsize" not implemented: %r' % self)
 
-    def getmtime(self, follow_symlinks: bool = True) -> float:
+    def getmtime(self, follow_symlinks: bool = False) -> float:
         """Return the time of last modification."""
         raise NotImplementedError('method "getmtime" not implemented: %r' % self)
 

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -738,7 +738,7 @@ class BasePath:
         """
         return self.rename(dst_path=dst_path, overwrite=overwrite)
 
-    def md5(self, recalculate: bool = False, followlinks: bool = False) -> str:
+    def md5(self, recalculate: bool = False, followlinks: bool = True) -> str:
         raise NotImplementedError(f"'md5' is unsupported on '{type(self)}'")
 
     def symlink(self, dst_path: "PathLike") -> None:

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -615,7 +615,7 @@ class BasePath:
         """Return the names of the entries in the directory the path points to."""
         raise NotImplementedError('method "listdir" not implemented: %r' % self)
 
-    def scandir(self) -> Iterator[FileEntry]:
+    def scandir(self):
         """
         Return an iterator of FileEntry objects corresponding to the entries
         in the directory.

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -738,7 +738,7 @@ class BasePath:
         """
         return self.rename(dst_path=dst_path, overwrite=overwrite)
 
-    def md5(self, recalculate: bool = False, followlinks: bool = True) -> str:
+    def md5(self, recalculate: bool = False, followlinks: bool = False) -> str:
         raise NotImplementedError(f"'md5' is unsupported on '{type(self)}'")
 
     def symlink(self, dst_path: "PathLike") -> None:

--- a/megfile/s3.py
+++ b/megfile/s3.py
@@ -161,9 +161,7 @@ def s3_isfile(path: PathLike, followlinks: bool = False) -> bool:
     return S3Path(path).is_file(followlinks)
 
 
-def s3_listdir(
-    path: PathLike, followlinks: bool = False, missing_ok: bool = True
-) -> List[str]:
+def s3_listdir(path: PathLike) -> List[str]:
     """
     Get all contents of given s3_url. The result is in ascending alphabetical order.
 
@@ -171,7 +169,7 @@ def s3_listdir(
     :returns: All contents have prefix of s3_url in ascending alphabetical order
     :raises: S3FileNotFoundError, S3NotADirectoryError
     """
-    return S3Path(path).listdir(followlinks, missing_ok)
+    return S3Path(path).listdir()
 
 
 def s3_load_from(path: PathLike, followlinks: bool = False) -> BinaryIO:
@@ -266,7 +264,7 @@ def s3_scandir(
     path: PathLike, followlinks: bool = False, missing_ok: bool = True
 ) -> Iterator[FileEntry]:
     """
-    Get all contents of given s3_url, the order of result is not guaranteed.
+    Get all contents of given s3_url, the order of result is in arbitrary order..
 
     :param path: Given path
     :returns: All contents have prefix of s3_url

--- a/megfile/s3.py
+++ b/megfile/s3.py
@@ -264,7 +264,7 @@ def s3_scandir(
     path: PathLike, followlinks: bool = False, missing_ok: bool = True
 ) -> Iterator[FileEntry]:
     """
-    Get all contents of given s3_url, the order of result is in arbitrary order..
+    Get all contents of given s3_url, the order of result is in arbitrary order.
 
     :param path: Given path
     :returns: All contents have prefix of s3_url

--- a/megfile/s3.py
+++ b/megfile/s3.py
@@ -73,9 +73,7 @@ __all__ = [
 ]
 
 
-def s3_access(
-    path: PathLike, mode: Access = Access.READ, followlinks: bool = False
-) -> bool:
+def s3_access(path: PathLike, mode: Access = Access.READ) -> bool:
     """
     Test if path has access permission described by mode
 
@@ -83,7 +81,7 @@ def s3_access(
     :param mode: access mode
     :returns: bool, if the bucket of s3_url has read/write access.
     """
-    return S3Path(path).access(mode, followlinks)
+    return S3Path(path).access(mode)
 
 
 def s3_exists(path: PathLike, followlinks: bool = False) -> bool:
@@ -172,7 +170,7 @@ def s3_listdir(path: PathLike) -> List[str]:
     return S3Path(path).listdir()
 
 
-def s3_load_from(path: PathLike, followlinks: bool = False) -> BinaryIO:
+def s3_load_from(path: PathLike) -> BinaryIO:
     """Read all content in binary on specified path and write into memory
 
     User should close the BinaryIO manually
@@ -180,7 +178,7 @@ def s3_load_from(path: PathLike, followlinks: bool = False) -> BinaryIO:
     :param path: Given path
     :returns: BinaryIO
     """
-    return S3Path(path).load(followlinks)
+    return S3Path(path).load()
 
 
 def s3_hasbucket(path: PathLike) -> bool:
@@ -260,9 +258,7 @@ def s3_scan_stat(
     return S3Path(path).scan_stat(missing_ok, followlinks)
 
 
-def s3_scandir(
-    path: PathLike, followlinks: bool = False, missing_ok: bool = True
-) -> Iterator[FileEntry]:
+def s3_scandir(path: PathLike) -> Iterator[FileEntry]:
     """
     Get all contents of given s3_url, the order of result is in arbitrary order.
 
@@ -270,7 +266,7 @@ def s3_scandir(
     :returns: All contents have prefix of s3_url
     :raises: S3FileNotFoundError, S3NotADirectoryError
     """
-    return S3Path(path).scandir(followlinks, missing_ok)
+    return S3Path(path).scandir()
 
 
 def s3_stat(path: PathLike, follow_symlinks=True) -> StatResult:
@@ -455,7 +451,6 @@ def s3_glob(
     path: PathLike,
     recursive: bool = True,
     missing_ok: bool = True,
-    followlinks: bool = False,
 ) -> List[str]:
     """Return s3 path list in ascending alphabetical order,
     in which path matches glob pattern
@@ -474,7 +469,6 @@ def s3_glob(
             path=path,
             recursive=recursive,
             missing_ok=missing_ok,
-            followlinks=followlinks,
         )
     )
 
@@ -483,7 +477,6 @@ def s3_glob_stat(
     path: PathLike,
     recursive: bool = True,
     missing_ok: bool = True,
-    followlinks: bool = False,
 ) -> Iterator[FileEntry]:
     """Return a generator contains tuples of path and file stat,
     in ascending alphabetical order, in which path matches glob pattern
@@ -499,7 +492,7 @@ def s3_glob_stat(
         in which paths match `s3_pathname`
     """
     return S3Path(path).glob_stat(
-        pattern="", recursive=recursive, missing_ok=missing_ok, followlinks=followlinks
+        pattern="", recursive=recursive, missing_ok=missing_ok
     )
 
 
@@ -507,7 +500,6 @@ def s3_iglob(
     path: PathLike,
     recursive: bool = True,
     missing_ok: bool = True,
-    followlinks: bool = False,
 ) -> Iterator[str]:
     """Return s3 path iterator in ascending alphabetical order,
     in which path matches glob pattern
@@ -522,7 +514,7 @@ def s3_iglob(
     :returns: An iterator contains paths match `s3_pathname`
     """
     for path_obj in S3Path(path).iglob(
-        pattern="", recursive=recursive, missing_ok=missing_ok, followlinks=followlinks
+        pattern="", recursive=recursive, missing_ok=missing_ok
     ):
         yield path_obj.path_with_protocol
 

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -2257,7 +2257,7 @@ class S3Path(URIPath):
                 if files or dirs or not current:
                     yield root, dirs, files
 
-    def md5(self, recalculate: bool = False, followlinks: bool = True) -> str:
+    def md5(self, recalculate: bool = False, followlinks: bool = False) -> str:
         """
         Get md5 meta info in files that uploaded/copied via megfile
 

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -1719,7 +1719,7 @@ class S3Path(URIPath):
 
     def iterdir(self) -> Iterator["S3Path"]:
         """
-        Get all contents of given s3_url. The order of result is in arbitrary order..
+        Get all contents of given s3_url. The order of result is in arbitrary order.
 
         :returns: All contents have prefix of s3_url
         :raises: S3FileNotFoundError, S3NotADirectoryError
@@ -2007,7 +2007,7 @@ class S3Path(URIPath):
         self, followlinks: bool = False, missing_ok: bool = False
     ) -> Iterator[FileEntry]:
         """
-        Get all contents of given s3_url, the order of result is in arbitrary order..
+        Get all contents of given s3_url, the order of result is in arbitrary order.
 
         :returns: All contents have prefix of s3_url
         :raises: S3BucketNotFoundError, S3FileNotFoundError, S3NotADirectoryError

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -2012,7 +2012,7 @@ class S3Path(URIPath):
             S3FileNotFoundError("No match any file in: %r" % self.path_with_protocol),
         )
 
-    def scandir(self) -> Iterator[FileEntry]:
+    def scandir(self) -> ContextIterator:
         """
         Get all contents of given s3_url, the order of result is in arbitrary order.
 

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -2271,7 +2271,7 @@ class S3Path(URIPath):
             hash_md5 = hashlib.md5()  # nosec
             for file_name in self.listdir():
                 chunk = (
-                    S3Path(s3_path_join(self.path_with_protocol, file_name))
+                    self.joinpath(file_name)
                     .md5(recalculate=recalculate, followlinks=followlinks)
                     .encode()
                 )

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -1722,17 +1722,8 @@ class S3Path(URIPath):
         :returns: All contents have prefix of s3_url in ascending alphabetical order
         :raises: S3FileNotFoundError, S3NotADirectoryError
         """
-        try:
-            entries = list(self.scandir())
-        except S3BucketNotFoundError:
-            raise
-        except S3FileNotFoundError:
-            _, key = parse_s3_url(self.path_with_protocol)
-            if not key:
-                return []
-            raise
-
-        return sorted([entry.name for entry in entries])
+        with self.scandir() as entries:
+            return sorted([entry.name for entry in entries])
 
     def iterdir(self) -> Iterator["S3Path"]:
         """
@@ -1741,8 +1732,9 @@ class S3Path(URIPath):
         :returns: All contents have prefix of s3_url
         :raises: S3FileNotFoundError, S3NotADirectoryError
         """
-        for entry in self.scandir():
-            yield self.joinpath(entry.name)
+        with self.scandir() as entries:
+            for entry in entries:
+                yield self.joinpath(entry.name)
 
     def load(self) -> BinaryIO:
         """Read all content in binary on specified path and write into memory

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -2074,7 +2074,7 @@ class S3Path(URIPath):
                     src_url = generate_s3_path(
                         self._protocol_with_profile, bucket, content["Key"]
                     )
-                    yield FileEntry(
+                    yield FileEntry(  # pytype: disable=wrong-arg-types
                         content["Key"][len(prefix) :],
                         src_url,
                         _make_stat_without_metadata(content, self.from_path(src_url)),

--- a/megfile/sftp.py
+++ b/megfile/sftp.py
@@ -619,7 +619,7 @@ def sftp_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = F
 
     :param path: Given path
     :param recalculate: Ignore this parameter, just for compatibility
-    :param followlinks: If is True, calculate md5 for real file
+    :param followlinks: Ignore this parameter, just for compatibility
 
     returns: md5 of file
     """

--- a/megfile/sftp.py
+++ b/megfile/sftp.py
@@ -613,13 +613,13 @@ def sftp_walk(
     return SftpPath(path).walk(followlinks)
 
 
-def sftp_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = True):
+def sftp_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = False):
     """
     Calculate the md5 value of the file
 
     :param path: Given path
     :param recalculate: Ignore this parameter, just for compatibility
-    :param followlinks: Ignore this parameter, just for compatibility
+    :param followlinks: If is True, calculate md5 for real file
 
     returns: md5 of file
     """

--- a/megfile/sftp.py
+++ b/megfile/sftp.py
@@ -659,6 +659,7 @@ def sftp_save_as(file_object: BinaryIO, path: PathLike):
 def sftp_open(
     path: PathLike,
     mode: str = "r",
+    *,
     buffering=-1,
     encoding: Optional[str] = None,
     errors: Optional[str] = None,
@@ -676,10 +677,12 @@ def sftp_open(
         decoding errors are to be handled—this cannot be used in binary mode.
     :returns: File-Like object
     """
-    return SftpPath(path).open(mode, buffering, encoding, errors)
+    return SftpPath(path).open(
+        mode, buffering=buffering, encoding=encoding, errors=errors
+    )
 
 
-def sftp_chmod(path: PathLike, mode: int, follow_symlinks: bool = True):
+def sftp_chmod(path: PathLike, mode: int, *, follow_symlinks: bool = True):
     """
     Change the file mode and permissions, like os.chmod().
 
@@ -687,7 +690,7 @@ def sftp_chmod(path: PathLike, mode: int, follow_symlinks: bool = True):
     :param mode: the file mode you want to change
     :param followlinks: Ignore this parameter, just for compatibility
     """
-    return SftpPath(path).chmod(mode, follow_symlinks)
+    return SftpPath(path).chmod(mode, follow_symlinks=follow_symlinks)
 
 
 def sftp_absolute(path: PathLike) -> "SftpPath":

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -610,7 +610,7 @@ class SftpPath(URIPath):
         """
         with self.scandir() as entries:
             for entry in entries:
-                yield self.from_path(entry.path)
+                yield self.joinpath(entry.name)
 
     def load(self) -> BinaryIO:
         """Read all content on specified path and write into memory

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -807,7 +807,7 @@ class SftpPath(URIPath):
             FileNotFoundError("No match any file in: %r" % self.path_with_protocol),
         )
 
-    def scandir(self) -> Iterator[FileEntry]:
+    def scandir(self) -> ContextIterator:
         """
         Get all content of given file path.
 

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -922,7 +922,7 @@ class SftpPath(URIPath):
         path = self._client.normalize(self._real_path)
         return self._generate_path_object(path, resolve=True)
 
-    def md5(self, recalculate: bool = False, followlinks: bool = True):
+    def md5(self, recalculate: bool = False, followlinks: bool = False):
         """
         Calculate the md5 value of the file
 
@@ -997,6 +997,7 @@ class SftpPath(URIPath):
     def open(
         self,
         mode: str = "r",
+        *,
         buffering=-1,
         encoding: Optional[str] = None,
         errors: Optional[str] = None,
@@ -1027,7 +1028,7 @@ class SftpPath(URIPath):
             )  # pytype: disable=wrong-arg-types
         return fileobj  # pytype: disable=bad-return-type
 
-    def chmod(self, mode: int, follow_symlinks: bool = True):
+    def chmod(self, mode: int, *, follow_symlinks: bool = True):
         """
         Change the file mode and permissions, like os.chmod().
 

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -922,19 +922,16 @@ class SftpPath(URIPath):
         path = self._client.normalize(self._real_path)
         return self._generate_path_object(path, resolve=True)
 
-    def md5(self, recalculate: bool = False, followlinks: bool = True):
+    def md5(self, recalculate: bool = False, followlinks: bool = False):
         """
         Calculate the md5 value of the file
 
         :param recalculate: Ignore this parameter, just for compatibility
-        :param followlinks: If is True, calculate md5 for real file
+        :param followlinks: Ignore this parameter, just for compatibility
 
         returns: md5 of file
         """
-        stat = self.stat(follow_symlinks=False)
-        if followlinks and stat.is_symlink():
-            return self.readlink().md5(recalculate=recalculate, followlinks=followlinks)
-        elif stat.is_dir():
+        if self.is_dir():
             hash_md5 = hashlib.md5()  # nosec
             for file_name in self.listdir():
                 chunk = (

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -597,7 +597,9 @@ class SftpPath(URIPath):
         :returns: All contents have in the path in ascending alphabetical order
         """
         stat = self.stat(follow_symlinks=False)
-        if not S_ISDIR(stat.st_mode):
+        if stat.is_symlink():
+            return self.readlink().listdir()
+        if not stat.is_dir():
             raise NotADirectoryError(f"Not a directory: '{self.path_with_protocol}'")
         return sorted(self._client.listdir(self._real_path))
 
@@ -608,7 +610,9 @@ class SftpPath(URIPath):
         :returns: All contents have in the path.
         """
         stat = self.stat(follow_symlinks=False)
-        if not S_ISDIR(stat.st_mode):
+        if stat.is_symlink():
+            return self.readlink().iterdir()
+        if not stat.is_dir():
             raise NotADirectoryError(f"Not a directory: '{self.path_with_protocol}'")
         for path in self._client.listdir(self._real_path):
             yield self.joinpath(path)

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -596,20 +596,21 @@ class SftpPath(URIPath):
 
         :returns: All contents have in the path in ascending alphabetical order
         """
-        if not self.is_dir():
+        stat = self.stat(follow_symlinks=False)
+        if not S_ISDIR(stat.st_mode):
             raise NotADirectoryError(f"Not a directory: '{self.path_with_protocol}'")
         return sorted(self._client.listdir(self._real_path))
 
     def iterdir(self) -> Iterator["SftpPath"]:
         """
-        Get all contents of given sftp path.
-        The result is in ascending alphabetical order.
+        Get all contents of given sftp path. The order of result is in arbitrary order..
 
-        :returns: All contents have in the path in ascending alphabetical order
+        :returns: All contents have in the path.
         """
-        if not self.is_dir():
+        stat = self.stat(follow_symlinks=False)
+        if not S_ISDIR(stat.st_mode):
             raise NotADirectoryError(f"Not a directory: '{self.path_with_protocol}'")
-        for path in self.listdir():
+        for path in self._client.listdir(self._real_path):
             yield self.joinpath(path)
 
     def load(self) -> BinaryIO:

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -922,16 +922,19 @@ class SftpPath(URIPath):
         path = self._client.normalize(self._real_path)
         return self._generate_path_object(path, resolve=True)
 
-    def md5(self, recalculate: bool = False, followlinks: bool = False):
+    def md5(self, recalculate: bool = False, followlinks: bool = True):
         """
         Calculate the md5 value of the file
 
         :param recalculate: Ignore this parameter, just for compatibility
-        :param followlinks: Ignore this parameter, just for compatibility
+        :param followlinks: If is True, calculate md5 for real file
 
         returns: md5 of file
         """
-        if self.is_dir():
+        stat = self.stat(follow_symlinks=False)
+        if followlinks and stat.is_symlink():
+            return self.readlink().md5(recalculate=recalculate, followlinks=followlinks)
+        elif stat.is_dir():
             hash_md5 = hashlib.md5()  # nosec
             for file_name in self.listdir():
                 chunk = (

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -605,7 +605,7 @@ class SftpPath(URIPath):
 
     def iterdir(self) -> Iterator["SftpPath"]:
         """
-        Get all contents of given sftp path. The order of result is in arbitrary order..
+        Get all contents of given sftp path. The order of result is in arbitrary order.
 
         :returns: All contents have in the path.
         """

--- a/megfile/smart.py
+++ b/megfile/smart.py
@@ -1081,13 +1081,14 @@ def smart_touch(path: PathLike):
         pass
 
 
-def smart_getmd5(path: PathLike, recalculate: bool = False):
+def smart_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = False):
     """Get md5 value of file
 
     param path: File path
     param recalculate: calculate md5 in real-time or not return s3 etag when path is s3
+    param followlinks: If is True, calculate md5 for real file
     """
-    return SmartPath(path).md5(recalculate=recalculate)
+    return SmartPath(path).md5(recalculate=recalculate, followlinks=followlinks)
 
 
 _concat_funcs = {"s3": s3_concat, "sftp": sftp_concat}

--- a/megfile/stdio.py
+++ b/megfile/stdio.py
@@ -12,6 +12,7 @@ __all__ = [
 def stdio_open(
     path: PathLike,
     mode: str = "rb",
+    *,
     encoding: Optional[str] = None,
     errors: Optional[str] = None,
     **kwargs,
@@ -26,4 +27,4 @@ def stdio_open(
     :param mode: Only supports 'rb' and 'wb' now
     :return: STDReader, STDWriter
     """
-    return StdioPath(path).open(mode, encoding, errors)
+    return StdioPath(path).open(mode, encoding=encoding, errors=errors)

--- a/megfile/stdio_path.py
+++ b/megfile/stdio_path.py
@@ -72,6 +72,7 @@ class StdioPath(BasePath):
     def open(
         self,
         mode: str = "rb",
+        *,
         encoding: Optional[str] = None,
         errors: Optional[str] = None,
         **kwargs,

--- a/tests/test_hdfs.py
+++ b/tests/test_hdfs.py
@@ -179,15 +179,41 @@ def test_hdfs_stat(http_mocker):
 
 
 def test_hdfs_isdir(http_mocker):
+    http_mocker.get(
+        "http://127.0.0.1:8000/webhdfs/v1/root/2?op=GETFILESTATUS",
+        status_code=404,
+        json={
+            "RemoteException": {
+                "exception": "FileNotFoundException",
+                "javaClassName": "java.io.FileNotFoundException",
+                "message": "File does not exist: /unknown",
+            }
+        },
+    )
+
     assert hdfs.hdfs_isdir("hdfs://root") is True
     assert hdfs.hdfs_isdir("hdfs://root/a") is True
     assert hdfs.hdfs_isdir("hdfs://root/1.txt") is False
+    assert hdfs.hdfs_isdir("hdfs://root/2") is False
 
 
 def test_hdfs_isfile(http_mocker):
+    http_mocker.get(
+        "http://127.0.0.1:8000/webhdfs/v1/root/2.txt?op=GETFILESTATUS",
+        status_code=404,
+        json={
+            "RemoteException": {
+                "exception": "FileNotFoundException",
+                "javaClassName": "java.io.FileNotFoundException",
+                "message": "File does not exist: /unknown",
+            }
+        },
+    )
+
     assert hdfs.hdfs_isfile("hdfs://root") is False
     assert hdfs.hdfs_isfile("hdfs://root/a") is False
     assert hdfs.hdfs_isfile("hdfs://root/a/2.txt") is True
+    assert hdfs.hdfs_isfile("hdfs://root/2.txt") is False
 
 
 def test_hdfs_listdir(http_mocker):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -717,6 +717,7 @@ def test_s3_listdir(truncating_client, mocker):
     assert s3.s3_listdir("s3://bucketA/folderAA") == ["folderAAA"]
     assert s3.s3_listdir("s3://bucketA/folderAB") == ["fileAB", "fileAC"]
     assert s3.s3_listdir("s3://bucketA/folderAB/") == ["fileAB", "fileAC"]
+    assert list(s3.s3_listdir("s3://bucketB/")) == []
     with pytest.raises(NotADirectoryError):
         s3.s3_listdir("s3://bucketA/fileAA")
     with pytest.raises(FileNotFoundError):
@@ -3488,6 +3489,7 @@ def test_symlink_relevant_functions(s3_empty_client, fs):
             assert file_entry.is_symlink() is False
         else:
             assert file_entry.stat.islnk is True
+            assert file_entry.stat.is_file() is True
             assert file_entry.stat.is_symlink() is True
             assert file_entry.is_symlink() is True
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -613,10 +613,15 @@ def test_s3_scandir_internal(truncating_client, mocker):
 
     # walk the dir that is not exist
     # expect: empty generator
-    assert list(s3.s3_scandir("s3://notExistBucket")) == []
-    assert list(s3.s3_scandir("s3://bucketA/notExistFile")) == []
-    assert list(s3.s3_scandir("s3+test://notExistBucket")) == []
-    assert list(s3.s3_scandir("s3+test://bucketA/notExistFile")) == []
+    with pytest.raises(FileNotFoundError):
+        list(s3.s3_scandir("s3://notExistBucket"))
+    with pytest.raises(FileNotFoundError):
+        list(s3.s3_scandir("s3://bucketA/notExistFile"))
+    assert list(s3.s3_scandir("s3://bucketB/")) == []
+    with pytest.raises(FileNotFoundError):
+        list(s3.s3_scandir("s3+test://notExistBucket"))
+    with pytest.raises(FileNotFoundError):
+        list(s3.s3_scandir("s3+test://bucketA/notExistFile"))
 
     def dir_entrys_to_tuples(entries: Iterable[FileEntry]) -> List[Tuple[str, bool]]:
         return sorted([(entry.name, entry.is_dir()) for entry in entries])
@@ -652,12 +657,6 @@ def test_s3_scandir_internal(truncating_client, mocker):
 
     with pytest.raises(NotADirectoryError):
         s3.s3_scandir("s3://bucketA/fileAA")
-    with pytest.raises(FileNotFoundError):
-        s3.s3_scandir("s3://notExistBucket", missing_ok=False)
-    with pytest.raises(FileNotFoundError):
-        s3.s3_scandir("s3://bucketA/notExistFolder", missing_ok=False)
-    with pytest.raises(S3BucketNotFoundError):
-        s3.s3_scandir("s3:///notExistFolder", missing_ok=False)
 
 
 def test_s3_scandir(truncating_client, mocker):
@@ -694,10 +693,6 @@ def test_s3_scandir(truncating_client, mocker):
 
     with pytest.raises(NotADirectoryError):
         s3.s3_scandir("s3://bucketA/fileAA")
-    with pytest.raises(FileNotFoundError):
-        s3.s3_scandir("s3://notExistBucket", missing_ok=False)
-    with pytest.raises(FileNotFoundError):
-        s3.s3_scandir("s3://bucketA/notExistFolder", missing_ok=False)
 
 
 def test_s3_listdir(truncating_client, mocker):
@@ -2715,7 +2710,7 @@ def test_s3_save_as_invalid(s3_empty_client):
 def test_s3_load_from(s3_empty_client):
     s3_empty_client.create_bucket(Bucket="bucket")
     s3_empty_client.put_object(Bucket="bucket", Key="key", Body=b"value")
-    content = s3.s3_load_from("s3://bucket/key", followlinks=True)
+    content = s3.s3_load_from("s3://bucket/key")
     assert content.read() == b"value"
 
 
@@ -3445,7 +3440,6 @@ def test_symlink_relevant_functions(s3_empty_client, fs):
     assert s3_path.S3Path("s3://bucket")._s3_get_metadata() == {}
     assert s3.s3_islink(dst_url) is True
     assert s3.s3_exists(A_dst_dst_url) is True
-    assert s3.s3_access(A_dst_url, Access.READ, followlinks=True) is True
     assert s3.s3_getsize(dst_url, follow_symlinks=False) == 0
     assert s3.s3_getsize(dst_url, follow_symlinks=True) == s3.s3_getsize(
         src_url, follow_symlinks=True
@@ -3457,11 +3451,8 @@ def test_symlink_relevant_functions(s3_empty_client, fs):
         src_url, followlinks=True
     )
 
-    assert s3.s3_load_from(dst_url, followlinks=True).read() == content
-    assert s3.s3_load_from(dst_url, followlinks=False).read() == b""
-    assert s3.s3_load_content(dst_url, followlinks=True) == content
-    assert s3.s3_load_content(dst_url, followlinks=False) == b""
-    assert s3.s3_load_content(copy_url, followlinks=True) == content
+    assert s3.s3_load_from(dst_url).read() == b""
+    assert s3.s3_load_content(dst_url) == b""
 
     assert list(s3.s3_scan_stat(A_dst_url))[0].is_symlink() is True
     s3.s3_sync(A_dst_url, sync_url)
@@ -3488,7 +3479,7 @@ def test_symlink_relevant_functions(s3_empty_client, fs):
         elif scan_entry.name == A_dst_dst_url:
             scan_entry.stat.is_symlink() is True
 
-    file_entries = list(s3.s3_scandir("s3://bucketA/pass/", followlinks=True))
+    file_entries = list(s3.s3_scandir("s3://bucketA/pass/"))
     assert len(file_entries) == 3
     for file_entry in file_entries:
         if file_entry.name == "src":
@@ -3539,16 +3530,7 @@ def test_symlink_relevant_functions(s3_empty_client, fs):
     )
 
     assert list(s3.s3_glob_stat(dst_url))[0].is_symlink() is True
-    assert list(s3.s3_glob_stat(dst_url, followlinks=True))[0].is_symlink() is True
     assert list(s3.s3_glob_stat(src_url))[0].is_symlink() is False
-    assert (
-        list(s3.s3_glob_stat(dst_url, followlinks=True))[0].stat.size
-        == list(s3.s3_glob_stat(src_url))[0].stat.size
-    )
-    assert (
-        list(s3.s3_glob_stat(dst_url, followlinks=True))[0].stat.mtime
-        == list(s3.s3_glob_stat(src_url))[0].stat.mtime
-    )
 
     s3.s3_rename(A_dst_url, A_rename_url)
     s3.s3_islink(A_rename_url)
@@ -3558,15 +3540,12 @@ def test_symlink_relevant_functions(s3_empty_client, fs):
     s3.s3_remove(A_src_url)
     s3.s3_exists(A_dst_url) is True
     s3.s3_exists(A_dst_url, followlinks=True) is False
-    assert s3.s3_access(A_dst_url, Access.READ, followlinks=True) == s3.s3_access(
-        A_src_url, Access.READ, followlinks=True
-    )
 
     s3.s3_remove(A_rename_url)
     s3.s3_remove(A_dst_dst_url)
     s3.s3_remove(sync_url)
     s3_empty_client.delete_bucket(Bucket="bucketA")
-    assert s3.s3_access(A_dst_dst_url, Access.READ, followlinks=True) is False
+    assert s3.s3_access(A_dst_dst_url, Access.READ) is False
 
 
 def test_s3_concat_small_file(s3_empty_client):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -725,9 +725,9 @@ def test_s3_listdir(truncating_client, mocker):
     with pytest.raises(NotADirectoryError):
         s3.s3_listdir("s3://bucketA/fileAA")
     with pytest.raises(FileNotFoundError):
-        s3.s3_listdir("s3://notExistBucket", missing_ok=False)
+        s3.s3_listdir("s3://notExistBucket")
     with pytest.raises(FileNotFoundError):
-        s3.s3_listdir("s3://bucketA/notExistFolder", missing_ok=False)
+        s3.s3_listdir("s3://bucketA/notExistFolder")
 
 
 def test_s3_isfile(s3_setup):
@@ -1345,10 +1345,6 @@ def test_s3_makedirs(mocker, s3_setup):
     assert "s3://bucketA/folderAB" in str(error.value)
 
     s3.s3_makedirs("s3://bucketA/folderAB", exist_ok=True)
-
-    with pytest.raises(FileExistsError) as error:
-        s3.s3_makedirs("s3://bucketA/fileAA", exist_ok=True)
-    assert "s3://bucketA/fileAA" in str(error.value)
 
 
 def test_s3_makedirs_no_bucket(mocker, s3_empty_client):

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -330,9 +330,9 @@ def test_sftp_scandir(sftp_mocker):
     with sftp.sftp_open("sftp://username@host//A/b/file.json", "w") as f:
         f.write("file")
 
-    assert [
-        file_entry.path for file_entry in sftp.sftp_scandir("sftp://username@host//A")
-    ] == [
+    assert sorted(
+        [file_entry.path for file_entry in sftp.sftp_scandir("sftp://username@host//A")]
+    ) == [
         "sftp://username@host//A/1.json",
         "sftp://username@host//A/a",
         "sftp://username@host//A/b",

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -338,6 +338,15 @@ def test_sftp_scandir(sftp_mocker):
         "sftp://username@host//A/b",
     ]
 
+    sftp.sftp_symlink("sftp://username@host//A", "sftp://username@host//B")
+    assert sorted(
+        [file_entry.path for file_entry in sftp.sftp_scandir("sftp://username@host//B")]
+    ) == [
+        "sftp://username@host//B/1.json",
+        "sftp://username@host//B/a",
+        "sftp://username@host//B/b",
+    ]
+
     with pytest.raises(FileNotFoundError):
         list(sftp.sftp_scandir("sftp://username@host//A/not_found"))
 

--- a/tests/test_sftp_path.py
+++ b/tests/test_sftp_path.py
@@ -86,7 +86,7 @@ def test_iterdir(sftp_mocker):
     with sftp.sftp_open("sftp://username@host//A/1.json", "w") as f:
         f.write("1.json")
 
-    assert list(SftpPath("sftp://username@host//A").iterdir()) == [
+    assert sorted(list(SftpPath("sftp://username@host//A").iterdir())) == [
         SftpPath("sftp://username@host//A/1.json"),
         SftpPath("sftp://username@host//A/a"),
         SftpPath("sftp://username@host//A/b"),


### PR DESCRIPTION
- Remove the `followlinks` parameter from `hdfs_listdir`, `hdfs_load_from`, `hdfs_scandir`, `HdfsPath.load`, `HdfsPath.scandir`, and keep the behavior as `followlinks=False`.
- Remove the `followlinks` parameter from `s3_access`, `s3_listdir`, `s3_load_from`, `s3_scandir`, `s3_glob`, `s3_glob_stat`, `s3_iglob`, `s3_load_content`, `S3Path.access`, `S3Path.listdir`, `S3Path.load`, `S3Path.scandir`, `S3Path.glob`, `S3Path.glob_stat`, `S3Path.iglob`, `S3Path.iterdir`, and keep the behavior as `followlinks=False`.
- Remove the `missing_ok` parameter from `s3_listdir`, `s3_scandir`, `S3Path.listdir`, `S3Path.scandir`, and set the default behavior to `missing_ok=False`.
- `Path.iterdir` and `Path.scandir` no longer guarantees dictionary order. If order is required, use `Path.listdir`.
- Fix the bug with `S3Path.scandir` where `stat.is_symlink` was incorrectly returned.
- Fix the bug with `SftpPath.listdir` throwing an error when the input is a symbolic link.