### PR TITLE
fix: retry unexpected eof while reading

### DIFF
--- a/megfile/errors.py
+++ b/megfile/errors.py
@@ -114,6 +114,8 @@ s3_retry_exceptions = tuple(s3_retry_exceptions)  # pyre-ignore[9]
 def s3_should_retry(error: Exception) -> bool:
     if isinstance(error, s3_retry_exceptions):  # pyre-ignore[6]
         return True
+    if isinstance(error, botocore.exceptions.SSLError):
+        return "EOF" in str(error)
     if isinstance(error, botocore.exceptions.ClientError):
         return client_error_code(error) in (
             "429",  # noqa: E501 # TOS ExceedAccountQPSLimit


### PR DESCRIPTION
```
megfile.errors.S3UnknownError: Unknown error encountered: 's3://bucket/key', error: botocore.exceptions.SSLError('SSL validation failed for https://bucket.oss-cn-beijing-internal.aliyuncs.com/key?uploadId=23D0F106649149C9A1320899D6A77C63&partNumber=11 [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1007)'), endpoint: 'https://oss-cn-beijing-internal.aliyuncs.com'
megfile.errors.S3UnknownError: Unknown error encountered: 's3://bucket/key', error: botocore.exceptions.SSLError('SSL validation failed for https://bucket.oss-cn-beijing-internal.aliyuncs.com/key?uploadId=789CA71B70B44AFE97043AD927215D04&partNumber=11 EOF occurred in violation of protocol (_ssl.c:2426)'), endpoint: 'https://oss-cn-beijing-internal.aliyuncs.com'

```

最近老吃到这种错，拦一手，看起来是在 ssl 握手时候吃到 eof 了，本质是网络问题

SSLError 这个类查了下存在 7 年了，应该不用做太多 fallback 检查