### PR TITLE
feat: do not retry in PrefetchReader

### DIFF
--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -8,7 +8,6 @@ from math import ceil
 from typing import Optional
 
 from megfile.config import (
-    DEFAULT_MAX_RETRY_TIMES,
     GLOBAL_MAX_WORKERS,
     NEWLINE,
     READER_BLOCK_SIZE,
@@ -34,7 +33,6 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
         block_size: int = READER_BLOCK_SIZE,
         max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
-        max_retries: int = DEFAULT_MAX_RETRY_TIMES,
         max_workers: Optional[int] = None,
         **kwargs,
     ):
@@ -70,7 +68,6 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
         # user maybe put block_size with 'numpy.uint64' type
         block_size = int(block_size)
 
-        self._max_retries = max_retries
         self._block_size = block_size
         self._block_capacity = block_capacity  # Max number of blocks
 

--- a/megfile/lib/http_prefetch_reader.py
+++ b/megfile/lib/http_prefetch_reader.py
@@ -7,10 +7,7 @@ from megfile.config import (
     READER_BLOCK_SIZE,
     READER_MAX_BUFFER_SIZE,
 )
-from megfile.errors import (
-    HttpBodyIncompleteError,
-    UnsupportedError,
-)
+from megfile.errors import UnsupportedError
 from megfile.lib.base_prefetch_reader import BasePrefetchReader
 from megfile.lib.compat import fspath
 from megfile.pathlike import PathLike
@@ -100,15 +97,6 @@ class HttpPrefetchReader(BasePrefetchReader):
                 stream=stream,
                 **request_kwargs,
             ) as response:
-                if len(response.content) != int(response.headers["Content-Length"]):
-                    raise HttpBodyIncompleteError(
-                        "The downloaded content is incomplete, "
-                        "expected size: %s, actual size: %d"
-                        % (
-                            response.headers["Content-Length"],
-                            len(response.content),
-                        )
-                    )
                 return {
                     "Body": BytesIO(response.content),
                     "Headers": response.headers,

--- a/megfile/lib/http_prefetch_reader.py
+++ b/megfile/lib/http_prefetch_reader.py
@@ -4,15 +4,12 @@ from typing import Optional
 import requests
 
 from megfile.config import (
-    HTTP_MAX_RETRY_TIMES,
     READER_BLOCK_SIZE,
     READER_MAX_BUFFER_SIZE,
 )
 from megfile.errors import (
     HttpBodyIncompleteError,
     UnsupportedError,
-    http_should_retry,
-    patch_method,
 )
 from megfile.lib.base_prefetch_reader import BasePrefetchReader
 from megfile.lib.compat import fspath
@@ -38,21 +35,21 @@ class HttpPrefetchReader(BasePrefetchReader):
         self,
         url: PathLike,
         *,
+        session: Optional[requests.Session] = None,
         content_size: Optional[int] = None,
         block_size: int = READER_BLOCK_SIZE,
         max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
-        max_retries: int = HTTP_MAX_RETRY_TIMES,
         max_workers: Optional[int] = None,
     ):
         self._url = url
         self._content_size = content_size
+        self._session = session
 
         super().__init__(
             block_size=block_size,
             max_buffer_size=max_buffer_size,
             block_forward=block_forward,
-            max_retries=max_retries,
             max_workers=max_workers,
         )
 
@@ -75,55 +72,46 @@ class HttpPrefetchReader(BasePrefetchReader):
     def _fetch_response(
         self, start: Optional[int] = None, end: Optional[int] = None
     ) -> dict:
-        def fetch_response() -> dict:
-            request_kwargs = {}
-            if hasattr(self._url, "request_kwargs"):
-                request_kwargs = self._url.request_kwargs  # pyre-ignore[16]
-            timeout = request_kwargs.pop("timeout", DEFAULT_TIMEOUT)
-            stream = request_kwargs.pop("stream", True)
+        request_kwargs = {}
+        if hasattr(self._url, "request_kwargs"):
+            request_kwargs = self._url.request_kwargs  # pyre-ignore[16]
+        timeout = request_kwargs.pop("timeout", DEFAULT_TIMEOUT)
+        stream = request_kwargs.pop("stream", True)
 
-            if start is None or end is None:
-                with requests.get(
-                    fspath(self._url), timeout=timeout, stream=stream, **request_kwargs
-                ) as response:
-                    return {
-                        "Headers": response.headers,
-                        "Cookies": response.cookies,
-                        "StatusCode": response.status_code,
-                    }
-            else:
-                range_end = end
-                if self._content_size is not None:
-                    range_end = min(range_end, self._content_size - 1)
-                headers = request_kwargs.pop("headers", {})
-                headers["Range"] = f"bytes={start}-{range_end}"
-                with requests.get(
-                    fspath(self._url),
-                    timeout=timeout,
-                    headers=headers,
-                    stream=stream,
-                    **request_kwargs,
-                ) as response:
-                    if len(response.content) != int(response.headers["Content-Length"]):
-                        raise HttpBodyIncompleteError(
-                            "The downloaded content is incomplete, "
-                            "expected size: %s, actual size: %d"
-                            % (
-                                response.headers["Content-Length"],
-                                len(response.content),
-                            )
+        if start is None or end is None:
+            with self._session.get(
+                fspath(self._url), timeout=timeout, stream=stream, **request_kwargs
+            ) as response:
+                return {
+                    "Headers": response.headers,
+                    "Cookies": response.cookies,
+                    "StatusCode": response.status_code,
+                }
+        else:
+            range_end = end
+            if self._content_size is not None:
+                range_end = min(range_end, self._content_size - 1)
+            headers = request_kwargs.pop("headers", {})
+            headers["Range"] = f"bytes={start}-{range_end}"
+            with self._session.get(
+                fspath(self._url),
+                timeout=timeout,
+                headers=headers,
+                stream=stream,
+                **request_kwargs,
+            ) as response:
+                if len(response.content) != int(response.headers["Content-Length"]):
+                    raise HttpBodyIncompleteError(
+                        "The downloaded content is incomplete, "
+                        "expected size: %s, actual size: %d"
+                        % (
+                            response.headers["Content-Length"],
+                            len(response.content),
                         )
-                    return {
-                        "Body": BytesIO(response.content),
-                        "Headers": response.headers,
-                        "Cookies": response.cookies,
-                        "StatusCode": response.status_code,
-                    }
-
-        fetch_response = patch_method(
-            fetch_response,
-            max_retries=self._max_retries,
-            should_retry=http_should_retry,
-        )
-
-        return fetch_response()
+                    )
+                return {
+                    "Body": BytesIO(response.content),
+                    "Headers": response.headers,
+                    "Cookies": response.cookies,
+                    "StatusCode": response.status_code,
+                }

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -5,7 +5,6 @@ from typing import Optional
 from megfile.config import (
     READER_BLOCK_SIZE,
     READER_MAX_BUFFER_SIZE,
-    S3_MAX_RETRY_TIMES,
 )
 from megfile.errors import (
     S3FileChangedError,
@@ -41,7 +40,6 @@ class S3PrefetchReader(BasePrefetchReader):
         block_size: int = READER_BLOCK_SIZE,
         max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
-        max_retries: int = S3_MAX_RETRY_TIMES,
         max_workers: Optional[int] = None,
         profile_name: Optional[str] = None,
     ):
@@ -55,7 +53,6 @@ class S3PrefetchReader(BasePrefetchReader):
             block_size=block_size,
             max_buffer_size=max_buffer_size,
             block_forward=block_forward,
-            max_retries=max_retries,
             max_workers=max_workers,
         )
 

--- a/tests/lib/test_http_prefetch_reader.py
+++ b/tests/lib/test_http_prefetch_reader.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 from io import BytesIO
@@ -92,7 +93,11 @@ def sleep_until_downloaded(reader, timeout: int = 5):
 
 def test_http_prefetch_reader(http_patch):
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=7
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=7,
     ) as reader:
         assert reader.name == URL
         assert reader.mode == "rb"
@@ -118,7 +123,11 @@ def test_http_prefetch_reader(http_patch):
         assert reader.read() == CONTENT
 
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=7
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=7,
     ) as reader:
         assert reader.read() == CONTENT
 
@@ -154,7 +163,11 @@ def test_http_prefetch_reader_readline(mocker):
 
 def test_http_prefetch_reader_readline_without_line_break_at_all(http_patch):
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=40
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=40,
     ) as reader:  # block_size > content_length
         reader.read(1)
         assert reader.readline() == b"lock0 block1 block2 block3 block4 "
@@ -163,7 +176,11 @@ def test_http_prefetch_reader_readline_without_line_break_at_all(http_patch):
 def test_http_prefetch_reader_readline_tailing_block(mocker):
     mocker.patch.object(SESSION, "get", return_value=FakeResponse200(b"123456"))
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=6, max_workers=2, block_size=3
+        URL,
+        session=SESSION,
+        content_size=6,
+        max_workers=2,
+        block_size=3,
     ) as reader:
         # next block is empty
         assert reader.readline() == b"123456"
@@ -173,7 +190,11 @@ def test_http_prefetch_reader_read_readline_mix(mocker):
     content = b"1\n2\n3\n4\n"
     mocker.patch.object(SESSION, "get", return_value=FakeResponse200(content))
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=len(content), max_workers=2, block_size=3
+        URL,
+        session=SESSION,
+        content_size=len(content),
+        max_workers=2,
+        block_size=3,
     ) as reader:
         assert reader.readline() == b"1\n"
         assert reader.read(2) == b"2\n"
@@ -187,7 +208,11 @@ def test_http_prefetch_reader_seek_out_of_range(mocker):
     content = b"1\n2\n3\n4\n"
     mocker.patch.object(SESSION, "get", return_value=FakeResponse200(b"1\n2\n3\n4\n"))
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=len(content), max_workers=2, block_size=3
+        URL,
+        session=SESSION,
+        content_size=len(content),
+        max_workers=2,
+        block_size=3,
     ) as reader:
         reader.seek(-2)
         assert reader.tell() == 0
@@ -213,7 +238,11 @@ def test_http_prefetch_reader_close(http_patch):
     assert reader.closed
 
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=1, block_size=1
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=1,
+        block_size=1,
     ) as reader:
         # 主线程休眠, 等待 reader.fetcher 线程阻塞在 _donwloading 事件上
         sleep_until_downloaded(reader)
@@ -450,36 +479,60 @@ def test_http_prefetch_reader_seek_and_the_target_out_of_buffer(http_patch):
 def test_http_prefetch_reader_read_with_forward_seek(http_patch):
     """向后 seek 后, 测试 read 结果的正确性"""
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=7
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=7,
     ) as reader:
         reader.seek(2)
         assert reader.read(4) == b"ock0"
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=7
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=7,
     ) as reader:
         reader.read(1)
         reader.seek(3)
         assert reader.read(4) == b"ck0 "
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=7
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=7,
     ) as reader:
         sleep_until_downloaded(reader)  # 休眠以确保 buffer 被填充满
         reader.seek(7)  # 目标 offset 距当前位置正好为一个 block 大小
         assert reader.read(7) == b"block1 "
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=7
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=7,
     ) as reader:
         reader.read(1)
         reader.seek(7)
         assert reader.read(7) == b"block1 "
 
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=7
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=7,
     ) as reader:
         reader.seek(21)
         assert reader.read(7) == b"block3 "
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=7
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=7,
     ) as reader:
         reader.seek(-1, os.SEEK_END)
         assert reader.read(2) == b" "
@@ -500,7 +553,11 @@ def test_http_prefetch_reader_tell(http_patch):
 
 def test_http_prefetch_reader_tell_after_seek(http_patch):
     with HttpPrefetchReader(
-        URL, session=SESSION, content_size=CONTENT_SIZE, max_workers=2, block_size=7
+        URL,
+        session=SESSION,
+        content_size=CONTENT_SIZE,
+        max_workers=2,
+        block_size=7,
     ) as reader:
         reader.seek(2)
         assert reader.tell() == 2
@@ -582,7 +639,41 @@ def test_http_prefetch_reader_headers(mocker):
     )
 
     with pytest.raises(UnsupportedError):
-        HttpPrefetchReader(
-            URL,
-            session=SESSION,
+        HttpPrefetchReader(URL, session=SESSION)
+
+
+def test_http_prefetch_reader_retry(mocker, caplog):
+    with caplog.at_level(logging.INFO, logger="megfile"):
+
+        class FakeResponse200Retry(FakeResponse200):
+            def __init__(self, content=CONTENT) -> None:
+                super().__init__(content)
+                self.times = 0
+
+            @property
+            def content(self):
+                self.times += 1
+                if self.times == 1:
+                    return b""
+                return super().content
+
+            @property
+            def status_code(self):
+                if self.times == 2:
+                    return 400
+                return super().status_code
+
+        fake_response = FakeResponse200Retry()
+        session = get_http_session(check_content_length=True)
+
+        mocker.patch.object(
+            session,
+            "send",
+            return_value=fake_response,
         )
+
+        with HttpPrefetchReader(URL, session=session) as fd:
+            content = fd.read()
+        assert "The downloaded content is incomplete" in caplog.text
+        assert content == CONTENT
+        assert fake_response.times >= 3


### PR DESCRIPTION
retry 统一在 client / session 上做，可以简化逻辑
1. 确认了下 S3PrefetchReader 拿到的 client 是带 retry 的，再包一次 retry 会导致重试次数过多
2. 把 HttpPrefetchReader 的 retry 也挪到 session 上实现，并把 session 作为参数传入 HttpPrefetchReader
3. 移除 PrefetchReader 上的 max_retries 参数

另外看到个奇怪的地方

get_http_session 上有个 status_forcelist 参数
1. status_forcelist 默认值是 (500, 502, 503, 504) 感觉有点 tricky，这些 status code 总感觉应该被重试
2. 但似乎除了测试，所有用到 get_http_session 都把 status_forcelist 设为空了，这参数是干啥的啊？