### PR TITLE
fix tos / oss upload issue for boto3 >= 1.36

### DIFF
--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -290,14 +290,23 @@ def get_s3_client(
             profile_name=profile_name,
         )
 
-    if config:
-        config = botocore.config.Config(
-            connect_timeout=5, max_pool_connections=GLOBAL_MAX_WORKERS
-        ).merge(config)
-    else:
-        config = botocore.config.Config(
-            connect_timeout=5, max_pool_connections=GLOBAL_MAX_WORKERS
+    try:
+        default_config = botocore.config.Config(
+            connect_timeout=5,
+            max_pool_connections=GLOBAL_MAX_WORKERS,
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
         )
+    except TypeError:  # botocore < 1.36.0
+        default_config = botocore.config.Config(
+            connect_timeout=5,
+            max_pool_connections=GLOBAL_MAX_WORKERS,
+        )
+
+    if config:
+        config = default_config.merge(config)
+    else:
+        config = default_config
 
     addressing_style = get_env_var("AWS_S3_ADDRESSING_STYLE", profile_name=profile_name)
     if addressing_style:

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -448,7 +448,10 @@ def test_get_s3_client_with_config(mocker):
 
     class EQConfig(botocore.config.Config):
         def __eq__(self, other):
-            return self._user_provided_options == other._user_provided_options
+            return (
+                self._user_provided_options[key] == other._user_provided_options[key]
+                for key in ("max_pool_connections", "connect_timeout")
+            )
 
     config = EQConfig(max_pool_connections=GLOBAL_MAX_WORKERS, connect_timeout=1)
     client = s3.get_s3_client(config)


### PR DESCRIPTION
boto3 在升级到 1.36 之后，部分默认配置改变导致在 tos / oss / obs(huawei) 上，upload object / upload part 会报错

相关 issue 包括

* https://github.com/boto/boto3/issues/4400
* https://github.com/boto/boto3/issues/4409

1. `An error occurred (InvalidArgument) when calling the PutObject operation: aws-chunked encoding is not supported with the specified x-amz-content-sha256 value.`
2. `An error occurred (ContentSHA256Mismatch) when calling the PutObject operation: The provided content-sha256 does not match what was computed.`

`1.36` 是大约 1 月份发版的，不过截止目前 boto3 已经升级到 `1.37` 也没计划修复这个问题，并且从维护者态度看估计未来也不会处理

https://github.com/boto/boto3/issues/4409#issuecomment-2620016816

![image](https://github.com/user-attachments/assets/3b07a523-c5fa-44a8-b440-832d41b248cb)

因此在 megfile 里改了下默认配置已获得最大程度的兼容