### PR TITLE
hotfix oss presign url fetch data

### DIFF
--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -117,7 +117,8 @@ class S3PrefetchReader(BasePrefetchReader):
             return fetch_response()
 
     def _fetch_buffer(self, index: int) -> BytesIO:
-        start, end = index * self._block_size, (index + 1) * self._block_size - 1
+        start = index * self._block_size
+        end = min((index + 1) * self._block_size - 1, self._content_size - 1)
         response = self._fetch_response(start=start, end=end)
         etag = response.get("ETag", None)
         if self._content_etag and etag and etag != self._content_etag:


### PR DESCRIPTION
oss 产生的 presign url 上，end 如果超过文件长度会返回整个文件，导致读错内容，这里修一下
过程是服务端自己实现了个 s3 接口做了鉴权，鉴权后 302 跳转到了一个 presign url 上，读取 presign url 时碰到了这个问题