### PR TITLE
better http impl

### DIFF
--- a/megfile/errors.py
+++ b/megfile/errors.py
@@ -154,6 +154,7 @@ def patch_method(
     before_callback: Optional[Callable] = None,
     after_callback: Optional[Callable] = None,
     retry_callback: Optional[Callable] = None,
+    verbose: bool = True,
 ):
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -165,7 +166,7 @@ def patch_method(
                 result = func(*args, **kwargs)
                 if after_callback is not None:
                     result = after_callback(result, *args, **kwargs)
-                if retries > 1:
+                if verbose and retries > 1:
                     _logger.info(f"Error already fixed by retry {retries - 1} times")
                 return result
             except Exception as error:
@@ -176,11 +177,12 @@ def patch_method(
                 if retries == max_retries:
                     raise
                 retry_interval = min(0.1 * 2**retries, 30)
-                _logger.info(
-                    "unknown error encountered: %s, retry in %0.1f seconds "
-                    "after %d tries"
-                    % (full_error_message(error), retry_interval, retries)
-                )
+                if verbose:
+                    _logger.info(
+                        "unknown error encountered: %s, retry in %0.1f seconds "
+                        "after %d tries"
+                        % (full_error_message(error), retry_interval, retries)
+                    )
                 time.sleep(retry_interval)
 
     return wrapper

--- a/megfile/lib/http_prefetch_reader.py
+++ b/megfile/lib/http_prefetch_reader.py
@@ -18,6 +18,8 @@ from megfile.lib.base_prefetch_reader import BasePrefetchReader
 from megfile.lib.compat import fspath
 from megfile.pathlike import PathLike
 
+DEFAULT_TIMEOUT = (60, 60 * 60 * 24)
+
 
 class HttpPrefetchReader(BasePrefetchReader):
     """

--- a/megfile/lib/http_prefetch_reader.py
+++ b/megfile/lib/http_prefetch_reader.py
@@ -18,8 +18,6 @@ from megfile.lib.base_prefetch_reader import BasePrefetchReader
 from megfile.lib.compat import fspath
 from megfile.pathlike import PathLike
 
-DEFAULT_TIMEOUT = (60, 60 * 60 * 24)
-
 
 class HttpPrefetchReader(BasePrefetchReader):
     """
@@ -38,6 +36,7 @@ class HttpPrefetchReader(BasePrefetchReader):
         self,
         url: PathLike,
         *,
+        session: Optional[requests.Session] = None,
         content_size: Optional[int] = None,
         block_size: int = READER_BLOCK_SIZE,
         max_buffer_size: int = READER_MAX_BUFFER_SIZE,
@@ -47,6 +46,7 @@ class HttpPrefetchReader(BasePrefetchReader):
     ):
         self._url = url
         self._content_size = content_size
+        self._session = session or requests.Session()
 
         super().__init__(
             block_size=block_size,
@@ -76,16 +76,8 @@ class HttpPrefetchReader(BasePrefetchReader):
         self, start: Optional[int] = None, end: Optional[int] = None
     ) -> dict:
         def fetch_response() -> dict:
-            request_kwargs = {}
-            if hasattr(self._url, "request_kwargs"):
-                request_kwargs = self._url.request_kwargs  # pyre-ignore[16]
-            timeout = request_kwargs.pop("timeout", DEFAULT_TIMEOUT)
-            stream = request_kwargs.pop("stream", True)
-
             if start is None or end is None:
-                with requests.get(
-                    fspath(self._url), timeout=timeout, stream=stream, **request_kwargs
-                ) as response:
+                with self._session.get(fspath(self._url), stream=True) as response:
                     return {
                         "Headers": response.headers,
                         "Cookies": response.cookies,
@@ -95,14 +87,9 @@ class HttpPrefetchReader(BasePrefetchReader):
                 range_end = end
                 if self._content_size is not None:
                     range_end = min(range_end, self._content_size - 1)
-                headers = request_kwargs.pop("headers", {})
-                headers["Range"] = f"bytes={start}-{range_end}"
-                with requests.get(
-                    fspath(self._url),
-                    timeout=timeout,
-                    headers=headers,
-                    stream=stream,
-                    **request_kwargs,
+                headers = {"Range": f"bytes={start}-{range_end}"}
+                with self._session.get(
+                    fspath(self._url), headers=headers, stream=True
                 ) as response:
                     if len(response.content) != int(response.headers["Content-Length"]):
                         raise HttpBodyIncompleteError(

--- a/tests/lib/test_http_prefetch_reader.py
+++ b/tests/lib/test_http_prefetch_reader.py
@@ -78,7 +78,8 @@ def _fake_get(*args, headers=None, **kwargs):
 @pytest.fixture
 def http_patch(mocker):
     requests_get_func = mocker.patch(
-        "megfile.http_path.requests.get", side_effect=_fake_get
+        "megfile.lib.http_prefetch_reader.requests.Session.get",
+        side_effect=_fake_get,
     )
     return requests_get_func
 
@@ -127,7 +128,8 @@ def test_http_prefetch_reader(http_patch):
 def test_http_prefetch_reader_readline(mocker):
     content = b"1\n2\n3\n\n4444\n5"
     mocker.patch(
-        "megfile.http_path.requests.get", return_value=FakeResponse200(content)
+        "megfile.lib.http_prefetch_reader.requests.Session.get",
+        return_value=FakeResponse200(content),
     )
     with HttpPrefetchReader(URL, max_workers=2, block_size=3) as reader:
         # within block
@@ -160,7 +162,8 @@ def test_http_prefetch_reader_readline_without_line_break_at_all(http_patch):
 
 def test_http_prefetch_reader_readline_tailing_block(mocker):
     mocker.patch(
-        "megfile.http_path.requests.get", return_value=FakeResponse200(b"123456")
+        "megfile.lib.http_prefetch_reader.requests.Session.get",
+        return_value=FakeResponse200(b"123456"),
     )
     with HttpPrefetchReader(URL, content_size=6, max_workers=2, block_size=3) as reader:
         # next block is empty
@@ -170,7 +173,8 @@ def test_http_prefetch_reader_readline_tailing_block(mocker):
 def test_http_prefetch_reader_read_readline_mix(mocker):
     content = b"1\n2\n3\n4\n"
     mocker.patch(
-        "megfile.http_path.requests.get", return_value=FakeResponse200(content)
+        "megfile.lib.http_prefetch_reader.requests.Session.get",
+        return_value=FakeResponse200(content),
     )
     with HttpPrefetchReader(
         URL, content_size=len(content), max_workers=2, block_size=3
@@ -186,7 +190,8 @@ def test_http_prefetch_reader_read_readline_mix(mocker):
 def test_http_prefetch_reader_seek_out_of_range(mocker):
     content = b"1\n2\n3\n4\n"
     mocker.patch(
-        "megfile.http_path.requests.get", return_value=FakeResponse200(b"1\n2\n3\n4\n")
+        "megfile.lib.http_prefetch_reader.requests.Session.get",
+        return_value=FakeResponse200(b"1\n2\n3\n4\n"),
     )
     with HttpPrefetchReader(
         URL, content_size=len(content), max_workers=2, block_size=3
@@ -568,7 +573,7 @@ def test_http_prefetch_reader_headers(mocker):
             return headers
 
     mocker.patch(
-        "megfile.http_path.requests.get",
+        "megfile.lib.http_prefetch_reader.requests.Session.get",
         return_value=FakeResponse200WithoutAcceptRange(),
     )
 
@@ -596,7 +601,7 @@ def test_http_prefetch_reader_retry(mocker, caplog):
         fake_response = FakeResponse200Retry()
 
         mocker.patch(
-            "megfile.http_path.requests.get",
+            "megfile.lib.http_prefetch_reader.requests.Session.get",
             return_value=fake_response,
         )
 


### PR DESCRIPTION
在用 megfile 下载 http 协议的数据，有多线程 prefetch 确实快，且还能直接输出到 s3 不用落盘
不过使用过程中发现

1. http 目前实现没有复用 session，按 requests 建议复用会比较好 https://requests.readthedocs.io/en/latest/user/advanced/
    > So if you’re making several requests to the same host, the underlying TCP connection will be reused, which can result in a significant performance increase
2. 有些 http 请求需要一些特殊的 auth header，因此抽出来个 DEFAULT_REQUEST_KWARGS 方便注入 headers
    因为很多时候用的是 smart_copy 之类的函数，实在离得太远，感觉靠传参得改太多接口，所以打算先这么凑合用用     
3. 顺便给 errors.patch_method 加了个 verbose 参数，方便控制是否打印 log，这函数我会在别的库也用，有时候错误多打印太多影响阅读