### PR TITLE
fix empty s3 file name issue

### DIFF
--- a/megfile/cli.py
+++ b/megfile/cli.py
@@ -70,17 +70,16 @@ def cli(debug, log_level):
     """
     options["debug"] = debug
     options["log_level"] = log_level or ("DEBUG" if debug else "INFO")
+    if not debug:
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
     set_log_level(options["log_level"])
 
 
 def safe_cli():  # pragma: no cover
-    debug = options.get("debug", False)
-    if not debug:
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
     try:
         cli()
     except Exception as e:
-        if debug:
+        if options.get("debug", False):
             raise
         else:
             click.echo(f"\n[{type(e).__name__}] {e}", err=True)


### PR DESCRIPTION
目前 megfile 对以 / 结尾的文件定义不一致
1. scan / glob / walk 之类的 list 文件的函数，把 / 结尾的文件当成一个文件名为空的文件
2. 其他对文件操作的函数，把 / 结尾的文件当成目录

这导致当目录中有 / 结尾的文件时，scan 会扫描出这种文件，但进一步 copy / open 时会报错

因此这个 PR 中修改了这部分的定义
1. 对于 scan / glob / walk 之类的 list 文件的函数，不再返回 / 结尾的文件
2. 有个特例是在 remove 中依然可以扫描到这种文件，以确保这种文件还能被正常删除