### PR TITLE
introduce lazy prefetch

### DIFF
--- a/megfile/config.py
+++ b/megfile/config.py
@@ -83,6 +83,7 @@ if READER_BLOCK_SIZE <= 0:
 READER_MAX_BUFFER_SIZE = parse_quantity(
     os.getenv("MEGFILE_READER_MAX_BUFFER_SIZE") or 128 * 2**20
 )
+READER_LAZY_PREFETCH = parse_boolean(os.getenv("MEGFILE_READER_LAZY_PREFETCH"), False)
 
 # Multi-upload in aws s3 has a maximum of 10,000 parts,
 # so the maximum supported file size is MEGFILE_WRITE_BLOCK_SIZE * 10,000,

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from megfile.config import (
     READER_BLOCK_SIZE,
+    READER_LAZY_PREFETCH,
     READER_MAX_BUFFER_SIZE,
     S3_MAX_RETRY_TIMES,
 )
@@ -62,7 +63,7 @@ class S3PrefetchReader(BasePrefetchReader):
         )
 
     def _get_content_size(self):
-        if self._block_capacity <= 0:
+        if self._block_capacity <= 0 or READER_LAZY_PREFETCH:
             response = self._client.head_object(Bucket=self._bucket, Key=self._key)
             self._content_etag = response.get("ETag")
             return int(response["ContentLength"])

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -1000,6 +1000,7 @@ def s3_buffered_open(
         )
 
     if mode == "rb":
+        block_size = block_size or READER_BLOCK_SIZE
         if share_cache_key is not None:
             reader = S3ShareCacheReader(
                 bucket,
@@ -1008,7 +1009,7 @@ def s3_buffered_open(
                 s3_client=client,
                 max_retries=max_retries,
                 max_workers=max_workers,
-                block_size=block_size or READER_BLOCK_SIZE,
+                block_size=block_size,
                 block_forward=block_forward,
                 profile_name=s3_url._profile_name,
             )
@@ -1023,13 +1024,14 @@ def s3_buffered_open(
                 max_workers=max_workers,
                 max_buffer_size=max_buffer_size,
                 block_forward=block_forward,
-                block_size=block_size or READER_BLOCK_SIZE,
+                block_size=block_size,
                 profile_name=s3_url._profile_name,
             )
         if buffered or _is_pickle(reader):
-            reader = io.BufferedReader(reader)  # type: ignore
+            reader = io.BufferedReader(reader, buffer_size=block_size)  # type: ignore
         return reader
 
+    block_size = block_size or WRITER_BLOCK_SIZE
     if limited_seekable:
         if max_buffer_size is None:
             max_buffer_size = WRITER_MAX_BUFFER_SIZE
@@ -1038,7 +1040,7 @@ def s3_buffered_open(
             key,
             s3_client=client,
             max_workers=max_workers,
-            block_size=block_size or WRITER_BLOCK_SIZE,
+            block_size=block_size,
             max_buffer_size=max_buffer_size,
             profile_name=s3_url._profile_name,
         )
@@ -1050,12 +1052,12 @@ def s3_buffered_open(
             key,
             s3_client=client,
             max_workers=max_workers,
-            block_size=block_size or WRITER_BLOCK_SIZE,
+            block_size=block_size,
             max_buffer_size=max_buffer_size,
             profile_name=s3_url._profile_name,
         )
     if buffered or _is_pickle(writer):
-        writer = io.BufferedWriter(writer)  # type: ignore
+        writer = io.BufferedWriter(writer, buffer_size=block_size)  # type: ignore
     return writer
 
 

--- a/megfile/utils/__init__.py
+++ b/megfile/utils/__init__.py
@@ -18,6 +18,7 @@ from io import (
 from threading import RLock
 from typing import IO, Callable, Optional
 
+from megfile.config import READER_LAZY_PREFETCH
 from megfile.utils.mutex import ProcessLocal, ThreadLocal
 
 
@@ -81,6 +82,9 @@ def is_writable(fileobj: IO) -> bool:
 
 def _is_pickle(fileobj) -> bool:
     """Test if File Object is pickle"""
+    if READER_LAZY_PREFETCH:
+        return False
+
     if fileobj.name.endswith(".pkl") or fileobj.name.endswith(".pickle"):
         return True
 


### PR DESCRIPTION
实现了 MEGFILE_READER_LAZY_PREFETCH 环境变量，用于控制一个 reader 是 lazy 的，即创建 reader 后不会立刻请求，直到第一次 read 时才会开始请求，期间可以做 seek 等操作

背景：业务使用时会打开大量文件文件句柄，每次都是从文件中间开始读一部分，这导致
1. prefetch reader 会在文件句柄打开时就开始从头读 128M，启动速度慢
2. 有些文件可以忍受读取慢，但希望读取他们的时候更省内存，避免 OOM

具体修改内容：
1. 增加 `MEGFILE_READER_LAZY_PREFETCH` 环境变量，因为是实验性功能，没有在 `smart_open` 接口上支持，先只用环境变量控制；找了下到底为什么 reader 创建的时候就会读取，发现有两处
    1. `_get_content_size` 之前为了优化，读了第一个块数据，改成了配置 `MEGFILE_READER_LAZY_PREFETCH` 的时候只做 head 了
    2. `_is_pickle` 这玩意 `read(2)` 结果触发了 prefetch，比 `_get_content_size` 开销还大，改成 `MEGFILE_READER_LAZY_PREFETCH` 的时候默认关闭了
2. 有时也希望 reader 更省内存，这时候会设置 `max_buffer_size=0`，这又产生另一个问题是 reader 行为上会变成要求读多少就读多少，会形成非常多小请求，因此也会同时打开 `buffered=True`，但这时 `io.BufferedReader` 默认缓存大小只有 16K，对 s3 来说每次请求还是很小，因此把 `block_size=8M` 赋值给 `io.BufferedReader` 的 `buffer_size` 方便每次读取的数据块还是 8M
3. `LRUCacheFutureManager` 和 `ShareCacheFutureManager` 加了一些 log 方便观察缓存的行为是否符合预期，另外把 `ShareCacheFutureManager` 之前叫 `key` 的变量都改名叫 `name` 了，跟 reader 里的称呼对齐
