### PR TITLE
sftp2 fix utime & chmod

### DIFF
--- a/megfile/sftp2_path.py
+++ b/megfile/sftp2_path.py
@@ -14,6 +14,7 @@ from urllib.parse import urlsplit, urlunsplit
 import ssh2.session  # type: ignore
 import ssh2.sftp  # type: ignore
 from ssh2.exceptions import SFTPProtocolError  # type: ignore
+from ssh2.sftp_handle import SFTPAttributes  # type: ignore
 
 from megfile.config import SFTP_MAX_RETRY_TIMES
 from megfile.errors import SameFileError, _create_missing_ok_generator
@@ -976,7 +977,9 @@ class Sftp2Path(URIPath):
 
     def chmod(self, mode: int, *, follow_symlinks: bool = True):
         """Change the file mode and permissions"""
-        return self._client.setstat(self._real_path, mode)
+        stat = SFTPAttributes()
+        stat.permissions = int(mode)
+        return self._client.setstat(self._real_path, stat)
 
     def absolute(self) -> "Sftp2Path":
         """Make the path absolute"""
@@ -1081,4 +1084,7 @@ class Sftp2Path(URIPath):
 
     def utime(self, atime: Union[float, int], mtime: Union[float, int]) -> None:
         """Set the access and modified times of the file"""
-        self._client.utime(self._real_path, (atime, mtime))
+        stat = SFTPAttributes()
+        stat.atime = int(atime)
+        stat.mtime = int(mtime)
+        self._client.setstat(self._real_path, stat)

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -1133,7 +1133,7 @@ class SftpPath(URIPath):
 
         src_stat = self.stat()
         dst_path.utime(src_stat.st_atime, src_stat.st_mtime)
-        dst_path._client.chmod(dst_path._real_path, src_stat.st_mode)
+        dst_path.chmod(src_stat.st_mode)
 
     def sync(
         self,

--- a/tests/test_sftp2.py
+++ b/tests/test_sftp2.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import stat
 import subprocess
-import time
 from typing import List
 
 import pytest
@@ -58,13 +57,11 @@ class FakeSFTP2Client:
     def symlink(self, source, dest):
         os.symlink(source, dest)
 
-    def setstat(self, path, mode):
-        os.chmod(path, mode)
-
-    def utime(self, path, times):
-        if times is None:
-            times = (time.time(), time.time())
-        os.utime(path, times)
+    def setstat(self, path, stat):
+        if stat.permissions != 0:
+            os.chmod(path, stat.permissions)
+        if stat.mtime != 0 or stat.atime != 0:
+            os.utime(path, (stat.atime, stat.mtime))
 
     def realpath(self, path):
         return os.path.realpath(path)


### PR DESCRIPTION
修一下 sftp2 utime / chmod 的实现，发现 ssh2 sftp 客户端的 setstat 传入一个 stat 对象而不是 int
python-ssh2 这包确实用户太少，在这包自己的 tests 里，以及上层包装 pssh 里都找不到一个调用 setstat 的例子，试了半天到底怎么用