### PR TITLE
support env config file

### DIFF
--- a/megfile/__init__.py
+++ b/megfile/__init__.py
@@ -1,3 +1,4 @@
+import megfile.config  # noqa: F401  # make sure env config is loaded
 from megfile.fs_path import FSPath, is_fs
 from megfile.hdfs_path import HdfsPath, is_hdfs
 from megfile.http_path import HttpPath, HttpsPath, is_http
@@ -7,6 +8,7 @@ from megfile.s3_path import (
     s3_buffered_open,
     s3_cached_open,
     s3_memory_open,
+    s3_open,
     s3_pipe_open,
     s3_prefetch_open,
     s3_share_cache_open,
@@ -114,6 +116,7 @@ __all__ = [
     "s3_buffered_open",
     "s3_cached_open",
     "s3_memory_open",
+    "s3_open",
     "s3_pipe_open",
     "s3_prefetch_open",
     "s3_share_cache_open",

--- a/megfile/config.py
+++ b/megfile/config.py
@@ -1,3 +1,4 @@
+import configparser
 import logging
 import os
 import typing as T
@@ -73,6 +74,25 @@ def set_log_level(level: T.Optional[T.Union[int, str]] = None):
     )
     level = level or os.getenv("MEGFILE_LOG_LEVEL") or logging.INFO
     logging.getLogger("megfile").setLevel(level)
+
+
+CONFIG_PATH = "~/.config/megfile/megfile.conf"
+
+
+def load_megfile_config(section) -> T.Dict[str, str]:
+    path = os.path.expanduser(CONFIG_PATH)
+    if not os.path.isfile(path):
+        return {}
+    config = configparser.ConfigParser()
+    if os.path.exists(path):
+        config.read(path)
+    if not config.has_section(section):
+        return {}
+    return dict(config.items(section))
+
+
+for key, value in load_megfile_config("env").items():
+    os.environ.setdefault(key.upper(), value)
 
 
 READER_BLOCK_SIZE = parse_quantity(os.getenv("MEGFILE_READER_BLOCK_SIZE") or 8 * 2**20)

--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -144,6 +144,7 @@ def _patch_execute_request(
         cmds = shlex.split(client.webdav.token_command)
         client.webdav.token_command_last_call = time.time()
         client.webdav.token = subprocess.check_output(cmds).decode().strip()
+        _logger.debug("update webdav token by command: %s", client.webdav.token_command)
 
     def webdav_should_retry(error: Exception) -> bool:
         if http_should_retry(error):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ from megfile.cli import (
     cli,
     config,
     cp,
+    env,
     hdfs,
     head,
     ll,
@@ -657,7 +658,7 @@ def test_config_alias(tmpdir, runner):
 
     config = configparser.ConfigParser()
     config.read(str(tmpdir / "config"))
-    assert config["a"]["protocol"] == "b"
+    assert config["alias"]["a"] == "b"
 
     result = runner.invoke(
         alias,
@@ -671,6 +672,49 @@ def test_config_alias(tmpdir, runner):
     )
     assert result.exit_code == 1
     assert isinstance(result.exc_info[1], NameError)
+
+
+def test_config_env(tmpdir, runner):
+    result = runner.invoke(
+        env,
+        [
+            "-p",
+            str(tmpdir / "config"),
+            "a=b",
+        ],
+    )
+    assert "Your env config" in result.output
+
+    config = configparser.ConfigParser()
+    config.read(str(tmpdir / "config"))
+    assert config["env"]["a"] == "b"
+
+    result = runner.invoke(
+        env,
+        [
+            "-p",
+            str(tmpdir / "config"),
+            "--no-cover",
+            "a=b",
+        ],
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exc_info[1], NameError)
+
+    # space
+    result = runner.invoke(
+        env,
+        [
+            "-p",
+            str(tmpdir / "config"),
+            "a=b c",
+        ],
+    )
+    assert "Your env config" in result.output
+
+    config = configparser.ConfigParser()
+    config.read(str(tmpdir / "config"))
+    assert config["env"]["a"] == "b c"
 
 
 def test_sftp_env(mocker):


### PR DESCRIPTION
### 主要改动

1. 设计了一个 megfile 的配置文件（~/.config/megfile/megfile.conf），使用 ini 格式（通过标准库 configparser 访问），目前在这里保存了
    1. alias 相关信息
    2. env 相关信息
2. 把 CLI 上 alias 命令改为写入新的配置文件，但旧的配置文件（~/.config/megfile/aliases.conf）也做了兼容处理，在旧的配置文件里的 alias 配置也会被读取
3. 在 CLI 上提供 env 命令，写入新的配置文件的 env section，计划通过这种方式，把一些 megfile 专用的环境变量持久化到文件里，避免不同 shell 环境变量不同导致的各种问题

### 已知问题

1. 为什么不是一个单独存放 env 的配置文件，例如 ~/.config/megfile/env 以 dotenv 格式存储
    * 文件多导致在 pod 里挂载更麻烦，一个配置也许是更优的方案
    * 未来统一一个配置时又要做额外兼容，太麻烦，不如尽量一步到位
2. 为什么用 ini 而不是其他
    * 配置文件可选格式包括 json / yaml / toml / ini，目前 megfile 使用的 ini 格式的配置文件更多，因此沿用
    * json 不太可读、yaml 还不错但对 megfile 没有使用这种格式的先例、toml 最可读但需要引入额外依赖
3. ini 表达能力有限，未来配置层级多了怎么办？
    * 暂时考虑像 toml 一样用 [a.b.c] 表达