### PR TITLE
try fix key error issue

### DIFF
--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -288,11 +288,11 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
                     self._submit_future(index)
             else:
                 self._submit_future(self._block_index)
-            self._cleanup_futures()
 
             self._cached_buffer = self._fetch_future_result(self._block_index)
             self._cached_buffer.seek(self._cached_offset)
             self._cached_offset = None
+            self._cleanup_futures()
 
         return self._cached_buffer
 


### PR DESCRIPTION
```
    smart_copy(
  File "/home/liyang/.local/lib/python3.10/site-packages/megfile/smart.py", line 367, in smart_copy
    copy_func(
  File "/home/liyang/.local/lib/python3.10/site-packages/megfile/smart.py", line 295, in _default_copy_func
    buf = fsrc.read(length)
  File "/home/liyang/.local/lib/python3.10/site-packages/megfile/lib/base_prefetch_reader.py", line 165, in read
    self.readinto(buffer)
  File "/home/liyang/.local/lib/python3.10/site-packages/megfile/lib/base_prefetch_reader.py", line 253, in readinto
    data = self._next_buffer.read(remain_size)
  File "/home/liyang/.local/lib/python3.10/site-packages/megfile/lib/base_prefetch_reader.py", line 307, in _next_buffer
    return self._buffer
  File "/home/liyang/.local/lib/python3.10/site-packages/megfile/lib/base_prefetch_reader.py", line 292, in _buffer
    self._cached_buffer = self._fetch_future_result(self._block_index)
  File "/home/liyang/.local/lib/python3.10/site-packages/megfile/lib/base_prefetch_reader.py", line 356, in _fetch_future_result
    return self._futures.result(index)
  File "/home/liyang/.local/lib/python3.10/site-packages/megfile/lib/base_prefetch_reader.py", line 384, in result
    self.move_to_end(key, last=True)
KeyError: 47
```

偶尔吃到这样的报错（很低频，似乎线程开的多更容易遇到），但没搞明白为什么
把 cleanup 挪到访问 key 之后，希望能避免（或减少）碰到上述错误的几率

目测就算修不掉，应该至少没啥副作用