### PR TITLE
Show HTTP proxy in S3 error messages for non-S3-format responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ PACKAGE := megfile
 VERSION := $(shell cat ${PACKAGE}/version.py | sed -n -E 's/.*=//; s/ //g; s/"//g; p')
 
 test:
+	# Ignore the developer's ~/.aws/config so a custom endpoint_url
+	# (e.g. Aliyun OSS) doesn't leak through moto's mock_aws and send
+	# real network calls. CI runners have no ~/.aws/config so this is
+	# a no-op there.
+	AWS_CONFIG_FILE=/dev/null \
 	pytest \
 		--cov=${PACKAGE} --cov-config=pyproject.toml --cov-report=html:html_cov/ --cov-report=term-missing --cov-report=xml --no-cov-on-fail \
 		--retries 2 --cumulative-timing 1 \

--- a/megfile/errors.py
+++ b/megfile/errors.py
@@ -87,6 +87,48 @@ def s3_endpoint_url(path: Optional[PathLike] = None):
     return endpoint_url
 
 
+def s3_proxy_url(endpoint_url: Optional[str]) -> Optional[str]:
+    """Return the proxy URL that botocore/urllib3 will use for ``endpoint_url``.
+
+    megfile does not configure proxies itself; the underlying HTTP stack
+    reads ``HTTPS_PROXY``/``HTTP_PROXY`` (and the lowercase variants) from
+    the environment. We mirror that lookup here so the proxy can be shown
+    in error messages — bad proxy configuration is a common cause of
+    client/server/connection errors.
+    """
+    if not endpoint_url:
+        return None
+    if endpoint_url.startswith("https://"):
+        return os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
+    if endpoint_url.startswith("http://"):
+        return os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy")
+    return None
+
+
+def s3_endpoint_extra(
+    path: Optional[PathLike] = None,
+    include_access_key: bool = False,
+    include_proxy: bool = False,
+) -> str:
+    """Build the ``endpoint: ..., access_key: ..., proxy: ...`` suffix used in
+    S3 error messages.
+
+    Set ``include_access_key=True`` for credential-related errors. Set
+    ``include_proxy=True`` for errors whose response body was likely not
+    S3-format XML (numeric HTTP codes, connection errors), since a
+    misconfigured proxy is a common cause of those.
+    """
+    endpoint_url = s3_endpoint_url(path)
+    extra = "endpoint: %r" % endpoint_url
+    if include_access_key:
+        extra += ", access_key: %r" % s3_access_key_masked(path)
+    if include_proxy:
+        proxy_url = s3_proxy_url(endpoint_url)
+        if proxy_url:
+            extra += ", proxy: %r" % proxy_url
+    return extra
+
+
 def s3_access_key_masked(path: Optional[PathLike] = None):
     from megfile.s3_path import get_access_token
 
@@ -400,7 +442,9 @@ class S3InvalidRangeError(S3Exception):
 
 class S3UnknownError(S3Exception, UnknownError):
     def __init__(self, error: Exception, path: PathLike, extra: Optional[str] = None):
-        super().__init__(error, path, extra or "endpoint: %r" % s3_endpoint_url(path))
+        super().__init__(
+            error, path, extra or s3_endpoint_extra(path, include_proxy=True)
+        )
 
 
 class HttpException(Exception):
@@ -486,46 +530,51 @@ def translate_s3_error(s3_error: Exception, s3_url: PathLike) -> Exception:
                 % (bucket_or_url, s3_endpoint_url(s3_url))
             )
         if code in ("404", "NoSuchKey"):
-            return S3FileNotFoundError("No such file: %r" % s3_url)
+            # A numeric "404" (rather than the named "NoSuchKey") usually
+            # means the response body was not S3-format XML — most often a
+            # proxy returning its own error page. Surface the proxy in that
+            # case so a misconfiguration is easy to spot.
+            return S3FileNotFoundError(
+                "No such file: %r, %s"
+                % (s3_url, s3_endpoint_extra(s3_url, include_proxy=code == "404"))
+            )
         if code in ("401", "403", "AccessDenied"):
-            message = client_error_message(s3_error)
+            # Same reasoning as the "404" branch above: numeric 401/403 is
+            # likely a proxy auth/redirect page rather than a real S3
+            # AccessDenied response.
             return S3PermissionError(
-                "Permission denied: %r, code: %r, message: %r, endpoint: %r, "
-                "access_key: %r. Hint: %s"
+                "Permission denied: %r, code: %r, message: %r, %s. Hint: %s"
                 % (
                     s3_url,
                     code,
-                    message,
-                    s3_endpoint_url(s3_url),
-                    s3_access_key_masked(s3_url),
+                    client_error_message(s3_error),
+                    s3_endpoint_extra(
+                        s3_url,
+                        include_access_key=True,
+                        include_proxy=code in ("401", "403"),
+                    ),
                     s3_config_hint(s3_url, "access_denied"),
                 )
             )
         if code == "InvalidAccessKeyId":
-            message = client_error_message(s3_error)
             return S3ConfigError(
-                "Invalid access key: %r, code: %r, message: %r, endpoint: %r, "
-                "access_key: %r. Hint: %s"
+                "Invalid access key: %r, code: %r, message: %r, %s. Hint: %s"
                 % (
                     s3_url,
                     code,
-                    message,
-                    s3_endpoint_url(s3_url),
-                    s3_access_key_masked(s3_url),
+                    client_error_message(s3_error),
+                    s3_endpoint_extra(s3_url, include_access_key=True),
                     s3_config_hint(s3_url, "invalid_access_key"),
                 )
             )
         if code == "SignatureDoesNotMatch":
-            message = client_error_message(s3_error)
             return S3ConfigError(
-                "Signature mismatch: %r, code: %r, message: %r, endpoint: %r, "
-                "access_key: %r. Hint: %s"
+                "Signature mismatch: %r, code: %r, message: %r, %s. Hint: %s"
                 % (
                     s3_url,
                     code,
-                    message,
-                    s3_endpoint_url(s3_url),
-                    s3_access_key_masked(s3_url),
+                    client_error_message(s3_error),
+                    s3_endpoint_extra(s3_url, include_access_key=True),
                     s3_config_hint(s3_url, "signature_mismatch"),
                 )
             )
@@ -558,37 +607,31 @@ def translate_s3_error(s3_error: Exception, s3_url: PathLike) -> Exception:
             return S3FileNotFoundError("No such file: %r" % s3_url)
         elif "AccessDenied" in str(s3_error):
             return S3PermissionError(
-                "AccessDenied: %r, message: %r, endpoint: %r, access_key: %r. "
-                "Hint: %s"
+                "AccessDenied: %r, message: %r, %s. Hint: %s"
                 % (
                     s3_url,
                     str(s3_error),
-                    s3_endpoint_url(s3_url),
-                    s3_access_key_masked(s3_url),
+                    s3_endpoint_extra(s3_url, include_access_key=True),
                     s3_config_hint(s3_url, "access_denied"),
                 )
             )
         elif "InvalidAccessKeyId" in str(s3_error):
             return S3ConfigError(
-                "InvalidAccessKeyId: %r, message: %r, endpoint: %r, access_key: %r. "
-                "Hint: %s"
+                "InvalidAccessKeyId: %r, message: %r, %s. Hint: %s"
                 % (
                     s3_url,
                     str(s3_error),
-                    s3_endpoint_url(s3_url),
-                    s3_access_key_masked(s3_url),
+                    s3_endpoint_extra(s3_url, include_access_key=True),
                     s3_config_hint(s3_url, "invalid_access_key"),
                 )
             )
         elif "SignatureDoesNotMatch" in str(s3_error):
             return S3ConfigError(
-                "SignatureDoesNotMatch: %r, message: %r, endpoint: %r, access_key: %r. "
-                "Hint: %s"
+                "SignatureDoesNotMatch: %r, message: %r, %s. Hint: %s"
                 % (
                     s3_url,
                     str(s3_error),
-                    s3_endpoint_url(s3_url),
-                    s3_access_key_masked(s3_url),
+                    s3_endpoint_extra(s3_url, include_access_key=True),
                     s3_config_hint(s3_url, "signature_mismatch"),
                 )
             )

--- a/megfile/utils/__init__.py
+++ b/megfile/utils/__init__.py
@@ -39,7 +39,11 @@ def get_content_size(fileobj: IO, *, intrusive: bool = False) -> int:
         if isinstance(file, TextIOBase):
             file = file.buffer
         if isinstance(file, BufferedIOBase):
-            file = file.raw
+            # ``BufferedReader`` / ``BufferedWriter`` wrap a raw ``FileIO`` we
+            # want to peek through. Some ``BufferedIOBase`` subclasses have no
+            # underlying raw (e.g. ``BytesIO``, including the one pyfakefs
+            # exposes as ``TextIOWrapper.buffer`` since 6.x) — keep them as-is.
+            file = getattr(file, "raw", file)
         if hasattr(file, "_content_size"):
             return getattr(file, "_content_size")  # pyre-ignore[16]
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -30,7 +30,9 @@ from megfile.errors import (
     patch_method,
     s3_access_key_masked,
     s3_config_hint,
+    s3_endpoint_extra,
     s3_endpoint_url,
+    s3_proxy_url,
     s3_retry_exceptions,
     s3_should_retry,
     translate_fs_error,
@@ -267,6 +269,160 @@ def test_s3_endpoint_url(mocker):
     assert s3_endpoint_url() == "test"
     assert s3_endpoint_url("s3+test1://") == "test1"
     assert s3_endpoint_url("s3+test2://") == "test2"
+
+
+def test_s3_proxy_url(monkeypatch):
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+
+    assert s3_proxy_url(None) is None
+    assert s3_proxy_url("") is None
+    assert s3_proxy_url("https://s3.amazonaws.com") is None
+    assert s3_proxy_url("http://s3.amazonaws.com") is None
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.example.com:8081")
+    assert s3_proxy_url("https://s3.amazonaws.com") == "http://proxy.example.com:8080"
+    assert s3_proxy_url("http://s3.amazonaws.com") == "http://proxy.example.com:8081"
+    assert s3_proxy_url("ftp://s3.amazonaws.com") is None
+
+    # Lowercase fallback when uppercase isn't set.
+    monkeypatch.delenv("HTTPS_PROXY")
+    monkeypatch.delenv("HTTP_PROXY")
+    monkeypatch.setenv("https_proxy", "http://lower.example.com:8080")
+    monkeypatch.setenv("http_proxy", "http://lower.example.com:8081")
+    assert s3_proxy_url("https://s3.amazonaws.com") == "http://lower.example.com:8080"
+    assert s3_proxy_url("http://s3.amazonaws.com") == "http://lower.example.com:8081"
+
+
+def test_s3_endpoint_extra(mocker, monkeypatch):
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+
+    mocker.patch(
+        "megfile.errors.s3_endpoint_url",
+        return_value="https://s3.amazonaws.com",
+    )
+    # Default: just endpoint, no access_key, no proxy.
+    assert (
+        s3_endpoint_extra("s3://bucket/key") == "endpoint: 'https://s3.amazonaws.com'"
+    )
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+    # Default still suppresses proxy even when env is set.
+    assert (
+        s3_endpoint_extra("s3://bucket/key") == "endpoint: 'https://s3.amazonaws.com'"
+    )
+    # Opt in to proxy.
+    assert s3_endpoint_extra("s3://bucket/key", include_proxy=True) == (
+        "endpoint: 'https://s3.amazonaws.com', proxy: 'http://proxy.example.com:8080'"
+    )
+
+    # access_key sits between endpoint and proxy.
+    mocker.patch("megfile.errors.s3_access_key_masked", return_value="AKIA****")
+    assert s3_endpoint_extra(
+        "s3://bucket/key", include_access_key=True, include_proxy=True
+    ) == (
+        "endpoint: 'https://s3.amazonaws.com', access_key: 'AKIA****', "
+        "proxy: 'http://proxy.example.com:8080'"
+    )
+
+
+def test_translate_s3_error_404_includes_endpoint_and_proxy(mocker, monkeypatch):
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    mocker.patch(
+        "megfile.errors.s3_endpoint_url",
+        return_value="https://s3.amazonaws.com",
+    )
+
+    # NoSuchKey: endpoint included, proxy NOT included even when set.
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+    error = translate_s3_error(
+        ClientError({"Error": {"Code": "NoSuchKey"}}, operation_name="test"),
+        "s3://bucket/key",
+    )
+    assert isinstance(error, S3FileNotFoundError)
+    assert "endpoint: 'https://s3.amazonaws.com'" in str(error)
+    assert "proxy" not in str(error)
+
+    # Numeric 404: both endpoint and proxy included.
+    error = translate_s3_error(
+        ClientError({"Error": {"Code": "404"}}, operation_name="test"),
+        "s3://bucket/key",
+    )
+    assert isinstance(error, S3FileNotFoundError)
+    assert "endpoint: 'https://s3.amazonaws.com'" in str(error)
+    assert "proxy: 'http://proxy.example.com:8080'" in str(error)
+
+    # Numeric 404 without proxy env: only endpoint, no proxy field.
+    monkeypatch.delenv("HTTPS_PROXY")
+    error = translate_s3_error(
+        ClientError({"Error": {"Code": "404"}}, operation_name="test"),
+        "s3://bucket/key",
+    )
+    assert "endpoint: 'https://s3.amazonaws.com'" in str(error)
+    assert "proxy" not in str(error)
+
+
+def test_translate_s3_error_permission_includes_proxy(mocker, monkeypatch):
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    mocker.patch(
+        "megfile.errors.s3_endpoint_url",
+        return_value="https://s3.amazonaws.com",
+    )
+    mocker.patch("megfile.errors.s3_access_key_masked", return_value="AKIA****")
+
+    # AccessDenied (named): no proxy even when env is set — server is real S3.
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+    error = translate_s3_error(
+        ClientError({"Error": {"Code": "AccessDenied"}}, operation_name="test"),
+        "s3://bucket/key",
+    )
+    assert isinstance(error, S3PermissionError)
+    assert "proxy" not in str(error)
+
+    # Numeric 401: includes proxy.
+    error = translate_s3_error(
+        ClientError({"Error": {"Code": "401"}}, operation_name="test"),
+        "s3://bucket/key",
+    )
+    assert isinstance(error, S3PermissionError)
+    assert "proxy: 'http://proxy.example.com:8080'" in str(error)
+
+    # Numeric 403: includes proxy.
+    error = translate_s3_error(
+        ClientError({"Error": {"Code": "403"}}, operation_name="test"),
+        "s3://bucket/key",
+    )
+    assert isinstance(error, S3PermissionError)
+    assert "proxy: 'http://proxy.example.com:8080'" in str(error)
+
+
+def test_s3_unknown_error_includes_proxy(mocker, monkeypatch):
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+
+    mocker.patch(
+        "megfile.errors.s3_endpoint_url",
+        return_value="https://s3.amazonaws.com",
+    )
+    error = S3UnknownError(Exception("boom"), "s3://bucket/key")
+    message = str(error)
+    assert "endpoint: 'https://s3.amazonaws.com'" in message
+    assert "proxy: 'http://proxy.example.com:8080'" in message
 
 
 def test_translate_hdfs_error():


### PR DESCRIPTION
Misconfigured HTTP/HTTPS proxies are a common cause of S3 errors, but the error messages did not mention the proxy, making it hard to spot.

When the response body is not S3-format XML (botocore falls back to the HTTP status code as `Code`), the response was likely intercepted by a proxy or other intermediary. In those cases, surface the proxy URL that botocore/urllib3 would use (read from `HTTPS_PROXY`/ `HTTP_PROXY`, picked by endpoint scheme):

- `S3UnknownError` catchall (covers connection errors, 5xx, unknown ClientError codes)
- numeric `404` (vs. named `NoSuchKey`, which is real S3)
- numeric `401`/`403` (vs. named `AccessDenied`, which is real S3)

Also include `endpoint` on `NoSuchKey` errors — files can appear "missing" simply because the wrong site/endpoint was used.

Refactor the duplicated `endpoint:`/`access_key:`/`proxy:` formatting into a single `s3_endpoint_extra(path, include_access_key, include_proxy)` helper used across all credential/auth error branches.