### PR TITLE
Fix WebDAV glob recursion

### DIFF
--- a/megfile/lib/glob.py
+++ b/megfile/lib/glob.py
@@ -200,6 +200,33 @@ def _isrecursive(pattern: str) -> bool:
     return pattern == "**"
 
 
+def split_magic(pathname: str) -> Tuple[str, str]:
+    """Split a glob path into the literal prefix and wildcard suffix."""
+    for i in range(len(pathname) - 1, 0, -1):
+        if not has_magic(pathname[:i]):
+            return pathname[:i], pathname[i:]
+    return pathname, ""
+
+
+def should_recursive_glob(wildcard_part: str, search_dir: bool = False) -> bool:
+    """Whether a bulk-listing backend must list recursively for this wildcard.
+
+    Local-style glob implementations can ignore this and keep expanding with
+    scandir one directory level at a time.
+    """
+    if "**" in wildcard_part:
+        return True
+    for expanded_path in ungloblize(wildcard_part):
+        parts_length = len(expanded_path.split("/"))
+        if parts_length + search_dir >= 2:
+            return True
+    return False
+
+
+def replace_recursive_wildcard(pathname: str) -> str:
+    return re.sub(r"\*{2,}", "*", pathname)
+
+
 def escape(pathname):
     """Escape all special characters."""
     # Escaping is done by wrapping any of "*?[" between square brackets.

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -64,7 +64,14 @@ from megfile.interfaces import (
 from megfile.lib.compare import is_same_file
 from megfile.lib.compat import fspath
 from megfile.lib.fnmatch import translate
-from megfile.lib.glob import has_magic, has_magic_ignore_brace, ungloblize
+from megfile.lib.glob import (
+    has_magic,
+    has_magic_ignore_brace,
+    replace_recursive_wildcard,
+    should_recursive_glob,
+    split_magic,
+    ungloblize,
+)
 from megfile.lib.joinpath import uri_join
 from megfile.lib.s3_buffered_writer import (
     S3BufferedWriter,
@@ -498,13 +505,6 @@ def _become_prefix(prefix: str) -> str:
     return prefix
 
 
-def _s3_split_magic(s3_pathname: str) -> Tuple[str, str]:
-    for i in range(len(s3_pathname) - 1, 0, -1):
-        if not has_magic(s3_pathname[:i]):
-            return s3_pathname[:i], s3_pathname[i:]
-    return s3_pathname, ""
-
-
 def _s3_list_objects(s3_client, bucket: str, prefix: str, delimiter: str = ""):
     # Use fast recursive listing when enabled and no delimiter
     if S3_FAST_LIST and delimiter == "":
@@ -806,20 +806,12 @@ def _s3_glob_stat_single_path(
     s3_pathname = fspath(s3_pathname)
     if not recursive:
         # If not recursive, replace ** with *
-        s3_pathname = re.sub(r"\*{2,}", "*", s3_pathname)
+        s3_pathname = replace_recursive_wildcard(s3_pathname)
     protocol, profile_name = _parse_s3_url_profile(s3_pathname)
-    top_prefix, wildcard_part = _s3_split_magic(s3_pathname)
+    top_prefix, wildcard_part = split_magic(s3_pathname)
     top_dir = os.path.dirname(top_prefix) if wildcard_part else top_prefix
     search_dir = wildcard_part.endswith("/")
-
-    def should_recursive(wildcard_part: str) -> bool:
-        if "**" in wildcard_part:
-            return True
-        for expanded_path in ungloblize(wildcard_part):
-            parts_length = len(expanded_path.split("/"))
-            if parts_length + search_dir >= 2:
-                return True
-        return False
+    recursive_scan = should_recursive_glob(wildcard_part, search_dir)
 
     def create_generator(_s3_pathname) -> Iterator[FileEntry]:
         if not has_magic(_s3_pathname):
@@ -834,7 +826,7 @@ def _s3_glob_stat_single_path(
             return
 
         delimiter = ""
-        if not should_recursive(wildcard_part):
+        if not recursive_scan:
             delimiter = "/"
 
         dirnames = set()

--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -40,8 +40,12 @@ from megfile.interfaces import (
 from megfile.lib.compare import is_same_file
 from megfile.lib.compat import fspath
 from megfile.lib.fnmatch import translate
-from megfile.lib.glob import has_magic
-from megfile.lib.joinpath import uri_join, uri_norm
+from megfile.lib.glob import (
+    has_magic,
+    replace_recursive_wildcard,
+    should_recursive_glob,
+    split_magic,
+)
 from megfile.lib.webdav_memory_handler import WebdavMemoryHandler, _webdav_stat
 from megfile.lib.webdav_prefetch_reader import WebdavPrefetchReader
 from megfile.pathlike import URIPath
@@ -287,14 +291,6 @@ def _webdav_scandir(client: WebdavClient, remote_path: str) -> List[dict]:
     return client.list(remote_path, get_info=True)
 
 
-def _webdav_split_magic(path: str) -> Tuple[str, str]:
-    parts = path.split("/")
-    for i in range(0, len(parts)):
-        if has_magic(parts[i]):
-            return "/".join(parts[:i]), "/".join(parts[i:])
-    return path, ""
-
-
 def _webdav_check_accept_ranges(client: WebdavClient, remote_path: str):
     urn = Urn(remote_path)
     response = client.execute_request(action="download", path=urn.quote())
@@ -422,21 +418,48 @@ class WebdavPath(URIPath):
             raise FileNotFoundError
         :returns: An iterator contains tuples of path and file stat
         """
-        remote_path = self._remote_path
+        glob_path = self.path_with_protocol
         if pattern:
-            remote_path = os.path.join(remote_path, pattern)
-        remote_path, pattern = _webdav_split_magic(remote_path)
-        root = os.path.relpath(remote_path, self._remote_path)
-        root = uri_join(self.path_with_protocol, root)
-        root = uri_norm(root)
-        pattern = re.compile(translate(pattern))
-        scan_func = _webdav_scan if recursive else _webdav_scandir
-        for info in scan_func(self._client, remote_path):
-            entry = _make_entry(info, remote_path, root)
-            relative = os.path.relpath(entry.path, root)
-            if not pattern.match(relative):
-                continue
-            yield entry
+            glob_path = self.joinpath(pattern).path_with_protocol
+        if not recursive:
+            glob_path = replace_recursive_wildcard(glob_path)
+
+        def create_generator() -> Iterator[FileEntry]:
+            if not has_magic(glob_path):
+                path_obj = self.from_path(glob_path)
+                if path_obj.exists():
+                    yield FileEntry(
+                        path_obj.name,
+                        path_obj.path_with_protocol,
+                        path_obj.stat(),
+                    )
+                return
+
+            remote_path = self.from_path(glob_path)._remote_path
+            top_prefix, wildcard_part = split_magic(remote_path)
+            search_dir = wildcard_part.endswith("/")
+            recursive_scan = should_recursive_glob(wildcard_part, search_dir)
+            compiled_pattern = re.compile(translate(glob_path))
+            root = self._generate_path_object(top_prefix)
+
+            scan_func = _webdav_scan if recursive_scan else _webdav_scandir
+            try:
+                infos = scan_func(root._client, root._remote_path)
+            except RemoteResourceNotFound:
+                return
+            for info in infos:
+                entry = _make_entry(info, root._remote_path, root.path_with_protocol)
+                match_path = (
+                    entry.path + "/" if search_dir and entry.is_dir() else entry.path
+                )
+                if compiled_pattern.match(match_path):
+                    yield entry
+
+        return _create_missing_ok_generator(
+            create_generator(),
+            missing_ok,
+            FileNotFoundError("No match any file: %r" % glob_path),
+        )
 
     def iglob(
         self, pattern, recursive: bool = True, missing_ok: bool = True

--- a/tests/lib/test_glob.py
+++ b/tests/lib/test_glob.py
@@ -589,6 +589,35 @@ def test_get_no_glob_root_path():
     )
 
 
+def test_should_recursive_glob():
+    assert glob.split_magic("s3://bucketA/{a/b,c}*/d") == (
+        "s3://bucketA/",
+        "{a/b,c}*/d",
+    )
+    assert glob.split_magic("s3+test://bucketA/{a/b,c}*/d") == (
+        "s3+test://bucketA/",
+        "{a/b,c}*/d",
+    )
+    assert glob.split_magic("s3+test://bucketA/{a/b,c}*/d//") == (
+        "s3+test://bucketA/",
+        "{a/b,c}*/d//",
+    )
+    assert glob.split_magic("s3://bucketA/a{/b,c}*") == (
+        "s3://bucketA/a",
+        "{/b,c}*",
+    )
+
+    top_prefix, wildcard_part = glob.split_magic("webdav://host/A/*/*.jsonl")
+    assert top_prefix == "webdav://host/A/"
+    assert wildcard_part == "*/*.jsonl"
+    assert glob.should_recursive_glob(wildcard_part) is True
+
+    top_prefix, wildcard_part = glob.split_magic("webdav://host/A/*.jsonl")
+    assert top_prefix == "webdav://host/A/"
+    assert wildcard_part == "*.jsonl"
+    assert glob.should_recursive_glob(wildcard_part) is False
+
+
 def test__iglob():
     with pytest.raises(OSError):
         list(glob._iglob("/root", True, dironly=True, fs=glob.DEFAULT_FILESYSTEM_FUNC))

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -46,7 +46,6 @@ from megfile.s3_path import (
     _parse_s3_url_profile,
     _patch_make_request,
     _s3_list_objects,
-    _s3_split_magic,
     _s3_split_magic_ignore_brace,
 )
 from megfile.utils import process_local, thread_local
@@ -2571,22 +2570,6 @@ def test_s3_glob_stat_cross_bucket(truncating_client, mocker):
                 missing_ok=False,
             )
         )
-
-
-def test_s3_split_magic():
-    assert _s3_split_magic("s3://bucketA/{a/b,c}*/d") == ("s3://bucketA/", "{a/b,c}*/d")
-    assert _s3_split_magic("s3+test://bucketA/{a/b,c}*/d") == (
-        "s3+test://bucketA/",
-        "{a/b,c}*/d",
-    )
-    assert _s3_split_magic("s3+test://bucketA/{a/b,c}*/d//") == (
-        "s3+test://bucketA/",
-        "{a/b,c}*/d//",
-    )
-    assert _s3_split_magic("s3://bucketA/a{/b,c}*") == (
-        "s3://bucketA/a",
-        "{/b,c}*",
-    )
 
 
 def test_group_s3path_by_bucket(truncating_client):

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -238,6 +238,15 @@ def test_webdav_glob(webdav_mocker):
         "webdav://host/A/1.json",
         "webdav://host/A/b/file.json",
     ]
+    assert webdav.webdav_glob("webdav://host/A/*/*.json") == [
+        "webdav://host/A/b/file.json",
+    ]
+    assert webdav.webdav_glob("webdav://host/A/*/*.json", recursive=False) == [
+        "webdav://host/A/b/file.json",
+    ]
+    assert webdav.webdav_glob("webdav://host/A/b/file.json") == [
+        "webdav://host/A/b/file.json",
+    ]
     assert [
         file_entry.path
         for file_entry in sorted(webdav.webdav_glob_stat("webdav://host/A/*"))

--- a/tests/test_webdav_path.py
+++ b/tests/test_webdav_path.py
@@ -75,6 +75,12 @@ def test_webdav_glob(webdav_mocker):
         "webdav://host/A/1.json",
         "webdav://host/A/b/file.json",
     ]
+    assert WebdavPath("webdav://host/A").glob("*/*.json") == [
+        "webdav://host/A/b/file.json",
+    ]
+    assert WebdavPath("webdav://host/A/b/file.json").glob("") == [
+        "webdav://host/A/b/file.json",
+    ]
     assert [
         file_entry.path
         for file_entry in sorted(WebdavPath("webdav://host/A").glob_stat("*"))


### PR DESCRIPTION
## Summary
- add recursive-listing glob helper for backends with shallow and recursive scan APIs
- use it in WebDAV glob so patterns like `*/*.jsonl` match nested files without forcing local-style traversal
- return actual file paths when glob is called with a non-magic WebDAV file path
- reuse the same recursive-scan decision in S3 while preserving `_s3_split_magic`

## Tests
- `pytest -q tests/lib/test_glob.py tests/test_webdav.py::test_webdav_glob tests/test_webdav_path.py::test_webdav_glob tests/test_webdav.py tests/test_webdav_path.py -k 'not test_provide_connect_info'`
- `python -m compileall -q megfile/lib/glob.py megfile/webdav_path.py megfile/s3_path.py`

Note: `test_provide_connect_info` is excluded locally because this devbox has real WebDAV credential env vars set, which changes that test's expected no-credential branch.