### PR TITLE
fix: guard WebDAV directory file operations

### DIFF
--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -725,8 +725,14 @@ class WebdavPath(URIPath):
 
         :param missing_ok: if False and target file not exists, raise FileNotFoundError
         """
-        if missing_ok and not self.exists():
-            return
+        try:
+            stat = self.stat()
+        except FileNotFoundError:
+            if missing_ok:
+                return
+            raise
+        if stat.isdir:
+            raise IsADirectoryError(f"Is a directory: '{self.path_with_protocol}'")
         try:
             self._client.clean(self._remote_path)
         except RemoteResourceNotFound:
@@ -841,14 +847,18 @@ class WebdavPath(URIPath):
         :param errors: error handling for text mode
         :returns: File-Like object
         """
-        if "x" in mode:
-            if self.exists():
-                raise FileExistsError("File exists: %r" % self.path_with_protocol)
+        try:
+            stat = self.stat()
+        except FileNotFoundError:
+            stat = None
+
+        if "x" in mode and stat is not None:
+            raise FileExistsError("File exists: %r" % self.path_with_protocol)
+        if stat is not None and stat.isdir:
+            raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
         if "w" in mode or "x" in mode or "a" in mode:
-            if self.is_dir():
-                raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
             self.parent.mkdir(parents=True, exist_ok=True)
-        elif not self.exists():
+        elif stat is None:
             raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
 
         if mode == "rb":

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -10,6 +10,7 @@ from webdav3.exceptions import (
     ResponseErrorCode,
 )
 
+from megfile import smart_copy
 from megfile.errors import SameFileError
 from megfile.webdav_path import _patch_execute_request
 from tests.compat import webdav
@@ -410,6 +411,14 @@ def test_webdav_open(webdav_mocker):
         with webdav.webdav_open("webdav://host/A", "w") as f:
             f.write("test")
 
+    with pytest.raises(IsADirectoryError):
+        with webdav.webdav_open("webdav://host/A", "r") as f:
+            f.read()
+
+    with pytest.raises(IsADirectoryError):
+        with webdav.webdav_open("webdav://host/A", "rb") as f:
+            f.read()
+
 
 def test_webdav_remove(webdav_mocker):
     webdav.webdav_makedirs("webdav://host/A")
@@ -466,6 +475,25 @@ def test_webdav_unlink(webdav_mocker):
 
     assert webdav.webdav_exists("webdav://host/A/test") is False
     assert webdav.webdav_exists("webdav://host/A") is True
+
+    client = webdav_mocker
+    clean = client.clean
+
+    def clean_should_not_be_called(path):
+        raise AssertionError("clean should not be called for missing_ok=True")
+
+    client.clean = clean_should_not_be_called
+    webdav.webdav_unlink("webdav://host/A/not_found", missing_ok=True)
+    client.clean = clean
+
+    with webdav.webdav_open("webdav://host/A/test", "w") as f:
+        f.write("test")
+
+    with pytest.raises(IsADirectoryError):
+        webdav.webdav_unlink("webdav://host/A")
+
+    assert webdav.webdav_exists("webdav://host/A") is True
+    assert webdav.webdav_exists("webdav://host/A/test") is True
 
 
 def test_webdav_walk(webdav_mocker):
@@ -570,6 +598,9 @@ def test_webdav_copy_error(webdav_mocker):
 
     with pytest.raises(IsADirectoryError):
         webdav.webdav_copy("webdav://host/A", "webdav://host/A2")
+
+    with pytest.raises(IsADirectoryError):
+        smart_copy("webdav://host/A", "webdav://host/A2")
 
     with pytest.raises(IsADirectoryError):
         webdav.webdav_copy("webdav://host/A/1.json", "webdav://host/A2/")


### PR DESCRIPTION
## Summary
- make WebDAV unlink reject directories before issuing DELETE
- make WebDAV open reject directories in read modes
- cover WebDAV unlink/open and smart_copy directory errors

## Tests
- pytest tests/test_webdav.py -q
- pytest tests/test_smart.py::test_smart_unlink tests/test_smart.py::test_smart_copy -q