### PR TITLE
perf: reduce redundant WebDAV and S3 metadata requests

### DIFF
--- a/megfile/errors.py
+++ b/megfile/errors.py
@@ -323,13 +323,17 @@ def patch_method(
     return wrapper
 
 
-def _create_missing_ok_generator(generator, missing_ok: bool, error: Exception):
+def _create_missing_ok_generator(
+    generator, missing_ok: bool, error: Exception, empty_ok: bool = False
+):
     if missing_ok:
         return generator
 
     try:
         first = next(generator)
     except StopIteration:
+        if empty_ok:
+            return iter(())
         raise error
 
     def create_generator():

--- a/megfile/lib/base_memory_handler.py
+++ b/megfile/lib/base_memory_handler.py
@@ -4,6 +4,7 @@ from io import BytesIO, UnsupportedOperation
 from typing import Iterable, List, Optional
 
 from megfile.interfaces import Readable, Seekable, Writable
+from megfile.pathlike import UNKNOWN_STAT, StatResult
 
 
 class BaseMemoryHandler(Readable[bytes], Seekable, Writable[bytes], ABC):
@@ -12,8 +13,10 @@ class BaseMemoryHandler(Readable[bytes], Seekable, Writable[bytes], ABC):
         mode: str,
         *,
         atomic: bool = False,
+        content_stat=UNKNOWN_STAT,
     ):
         self._mode = mode
+        self._content_stat = content_stat
 
         if mode not in ("rb", "wb", "ab", "rb+", "wb+", "ab+"):
             raise ValueError("unacceptable mode: %r" % mode)
@@ -88,6 +91,13 @@ class BaseMemoryHandler(Readable[bytes], Seekable, Writable[bytes], ABC):
     @abstractmethod
     def _upload_fileobj(self):
         pass
+
+    def _known_file_exists(self) -> Optional[bool]:
+        if isinstance(self._content_stat, StatResult):
+            return self._content_stat.is_file()
+        if self._content_stat is None:
+            return False
+        return None
 
     def _close(self, need_upload: bool = True):
         if hasattr(self, "_fileobj"):

--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -15,6 +15,7 @@ from megfile.config import (
     READER_MAX_BUFFER_SIZE,
 )
 from megfile.interfaces import Readable, Seekable
+from megfile.pathlike import UNKNOWN_STAT, StatResult
 from megfile.utils import ProcessLocal, process_local
 
 _logger = get_logger(__name__)
@@ -36,8 +37,10 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
         block_forward: Optional[int] = None,
         max_retries: int = DEFAULT_MAX_RETRY_TIMES,
         max_workers: Optional[int] = None,
+        content_stat=UNKNOWN_STAT,
         **kwargs,
     ):
+        self._content_stat = content_stat
         self._is_global_executor = False
         if max_workers is None:
             self._executor = process_local(
@@ -89,8 +92,13 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
 
         _logger.debug("open file: %r, mode: %s" % (self.name, self.mode))
 
-    @abstractmethod
     def _get_content_size(self):
+        if isinstance(self._content_stat, StatResult):
+            return int(self._content_stat.size)
+        return self._get_content_size_from_remote()
+
+    @abstractmethod
+    def _get_content_size_from_remote(self):
         pass  # pragma: no cover
 
     @property

--- a/megfile/lib/hdfs_prefetch_reader.py
+++ b/megfile/lib/hdfs_prefetch_reader.py
@@ -45,7 +45,7 @@ class HdfsPrefetchReader(BasePrefetchReader):
             max_workers=max_workers,
         )
 
-    def _get_content_size(self):
+    def _get_content_size_from_remote(self):
         with raise_hdfs_error(self._path):
             return self._client.status(self._path)["length"]
 

--- a/megfile/lib/http_prefetch_reader.py
+++ b/megfile/lib/http_prefetch_reader.py
@@ -58,7 +58,7 @@ class HttpPrefetchReader(BasePrefetchReader):
             max_workers=max_workers,
         )
 
-    def _get_content_size(self) -> int:
+    def _get_content_size_from_remote(self) -> int:
         if self._content_size is not None:
             return self._content_size
 

--- a/megfile/lib/s3_memory_handler.py
+++ b/megfile/lib/s3_memory_handler.py
@@ -8,6 +8,7 @@ from megfile.errors import (
     translate_s3_error,
 )
 from megfile.lib.base_memory_handler import BaseMemoryHandler
+from megfile.pathlike import UNKNOWN_STAT
 
 
 class S3MemoryHandler(BaseMemoryHandler):
@@ -20,12 +21,13 @@ class S3MemoryHandler(BaseMemoryHandler):
         s3_client,
         profile_name: Optional[str] = None,
         atomic: bool = False,
+        content_stat=UNKNOWN_STAT,
     ):
         self._bucket = bucket
         self._key = key
         self._client = s3_client
         self._profile_name = profile_name
-        super().__init__(mode=mode, atomic=atomic)
+        super().__init__(mode=mode, atomic=atomic, content_stat=content_stat)
 
     @property
     def name(self) -> str:
@@ -36,6 +38,9 @@ class S3MemoryHandler(BaseMemoryHandler):
         return translate_s3_error(error, self.name)
 
     def _file_exists(self) -> bool:
+        file_exists = self._known_file_exists()
+        if file_exists is not None:
+            return file_exists
         try:
             self._client.head_object(Bucket=self._bucket, Key=self._key)
         except Exception as error:

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -62,7 +62,7 @@ class S3PrefetchReader(BasePrefetchReader):
             max_workers=max_workers,
         )
 
-    def _get_content_size(self):
+    def _get_content_size_from_remote(self):
         if self._block_capacity <= 0 or READER_LAZY_PREFETCH:
             response = self._client.head_object(Bucket=self._bucket, Key=self._key)
             self._content_etag = response.get("ETag")

--- a/megfile/lib/webdav_memory_handler.py
+++ b/megfile/lib/webdav_memory_handler.py
@@ -8,6 +8,7 @@ from webdav3.exceptions import (
 )
 
 from megfile.lib.base_memory_handler import BaseMemoryHandler
+from megfile.pathlike import UNKNOWN_STAT
 
 
 def _webdav_stat(client: WebdavClient, remote_path: str):
@@ -26,13 +27,14 @@ def _webdav_stat(client: WebdavClient, remote_path: str):
 
 
 @wrap_connection_error
-def _webdav_download_from(client: WebdavClient, buff, remote_path):
+def _webdav_download_from(client: WebdavClient, buff, remote_path, *, check=True):
     urn = Urn(remote_path)
-    if client.is_dir(urn.path()):
-        raise OptionNotValid(name="remote_path", value=remote_path)
+    if check:
+        if client.is_dir(urn.path()):
+            raise OptionNotValid(name="remote_path", value=remote_path)
 
-    if not client.check(urn.path()):
-        raise RemoteResourceNotFound(urn.path())
+        if not client.check(urn.path()):
+            raise RemoteResourceNotFound(urn.path())
 
     response = client.execute_request(action="download", path=urn.quote())
 
@@ -49,17 +51,21 @@ class WebdavMemoryHandler(BaseMemoryHandler):
         webdav_client: WebdavClient,
         name: str,
         atomic: bool = False,
+        content_stat=UNKNOWN_STAT,
     ):
         self._remote_path = remote_path
         self._client = webdav_client
         self._name = name
-        super().__init__(mode=mode, atomic=atomic)
+        super().__init__(mode=mode, atomic=atomic, content_stat=content_stat)
 
     @property
     def name(self) -> str:
         return self._name
 
     def _file_exists(self) -> bool:
+        file_exists = self._known_file_exists()
+        if file_exists is not None:
+            return file_exists
         try:
             return not _webdav_stat(self._client, self._remote_path)["isdir"]
         except RemoteResourceNotFound:
@@ -71,7 +77,12 @@ class WebdavMemoryHandler(BaseMemoryHandler):
         if not need_download:
             return
         # directly download to the file handle
-        _webdav_download_from(self._client, self._fileobj, self._remote_path)
+        _webdav_download_from(
+            self._client,
+            self._fileobj,
+            self._remote_path,
+            check=self._known_file_exists() is None,
+        )
         if self._mode[0] == "r":
             self.seek(0, os.SEEK_SET)
 

--- a/megfile/lib/webdav_prefetch_reader.py
+++ b/megfile/lib/webdav_prefetch_reader.py
@@ -16,6 +16,7 @@ from megfile.errors import (
 )
 from megfile.lib.base_prefetch_reader import BasePrefetchReader
 from megfile.lib.webdav_memory_handler import _webdav_stat
+from megfile.pathlike import UNKNOWN_STAT
 
 DEFAULT_TIMEOUT = (60, 60 * 60 * 24)
 
@@ -38,6 +39,7 @@ class WebdavPrefetchReader(BasePrefetchReader):
         remote_path: str,
         *,
         client: Optional[WebdavClient] = None,
+        content_stat=UNKNOWN_STAT,
         block_size: int = READER_BLOCK_SIZE,
         max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
@@ -54,9 +56,10 @@ class WebdavPrefetchReader(BasePrefetchReader):
             block_forward=block_forward,
             max_retries=max_retries,
             max_workers=max_workers,
+            content_stat=content_stat,
         )
 
-    def _get_content_size(self) -> int:
+    def _get_content_size_from_remote(self) -> int:
         info = _webdav_stat(self._client, self._remote_path)
         return int(info.get("size") or 0)
 

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -24,6 +24,7 @@ from megfile.lib.fnmatch import _compile_pattern
 from megfile.lib.joinpath import uri_join
 
 Self = TypeVar("Self")
+UNKNOWN_STAT = object()
 
 
 class Access(Enum):

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -816,9 +816,11 @@ def _s3_glob_stat_single_path(
     def create_generator(_s3_pathname) -> Iterator[FileEntry]:
         if not has_magic(_s3_pathname):
             _s3_pathname_obj = S3Path(_s3_pathname)
-            if _s3_pathname_obj.is_file():
-                stat = _s3_pathname_obj.stat(follow_symlinks=followlinks)
+            try:
+                stat = _s3_pathname_obj._get_file_stat(follow_symlinks=followlinks)
                 yield FileEntry(_s3_pathname_obj.name, _s3_pathname_obj.path, stat)
+            except S3FileNotFoundError:
+                pass
             if _s3_pathname_obj.is_dir():
                 yield FileEntry(
                     _s3_pathname_obj.name, _s3_pathname_obj.path, StatResult(isdir=True)
@@ -2226,12 +2228,12 @@ class S3Path(URIPath):
         def create_generator() -> Iterator[FileEntry]:
             # On s3, file and directory may be of same name and level, so need
             # to test the path is file or directory
-            if not key.endswith("/") and self.is_file():
-                yield FileEntry(
-                    self.name,
-                    fspath(self.path_with_protocol),
-                    self.stat(follow_symlinks=followlinks),
-                )
+            if not key.endswith("/"):
+                try:
+                    stat = self._get_file_stat(follow_symlinks=followlinks)
+                    yield FileEntry(self.name, fspath(self.path_with_protocol), stat)
+                except S3FileNotFoundError:
+                    pass
 
             prefix = _become_prefix(key)
             protocol = self._protocol_with_profile
@@ -2323,24 +2325,27 @@ class S3Path(URIPath):
                         _make_stat_without_metadata(content, self.from_path(path)),
                     )
 
-        def missing_ok_generator():
-            def suppress_error_callback(e):
-                if isinstance(e, S3BucketNotFoundError):
-                    return False
-                elif not key and isinstance(e, S3FileNotFoundError):
-                    return True
+        def suppress_error_callback(e):
+            if isinstance(e, S3BucketNotFoundError):
                 return False
+            elif not key and isinstance(e, S3FileNotFoundError):
+                return True
+            return False
 
+        def raise_s3_error_generator():
             with raise_s3_error(self.path_with_protocol, suppress_error_callback):
-                yield from _create_missing_ok_generator(
-                    create_generator(),
-                    missing_ok=False,
-                    error=S3FileNotFoundError(
-                        "No such directory: %r" % self.path_with_protocol
-                    ),
-                )
+                yield from create_generator()
 
-        return ContextIterator(missing_ok_generator())
+        missing_ok_generator = _create_missing_ok_generator(
+            raise_s3_error_generator(),
+            missing_ok=False,
+            error=S3FileNotFoundError(
+                "No such directory: %r" % self.path_with_protocol
+            ),
+            empty_ok=not key,
+        )
+
+        return ContextIterator(missing_ok_generator)
 
     def _get_dir_stat(self) -> StatResult:
         """
@@ -2375,6 +2380,34 @@ class S3Path(URIPath):
 
         return StatResult(size=size, mtime=mtime, isdir=True)
 
+    def _get_file_stat(self, follow_symlinks: bool = True) -> StatResult:
+        islnk = False
+        bucket, key = parse_s3_url(self.path_with_protocol)
+        if not bucket:
+            raise S3BucketNotFoundError(
+                "Empty bucket name: %r" % self.path_with_protocol
+            )
+        if not key or key.endswith("/"):
+            raise S3FileNotFoundError("No such file: %r" % self.path_with_protocol)
+
+        with raise_s3_error(self.path_with_protocol):
+            content = self._client.head_object(Bucket=bucket, Key=key)
+            metadata = {
+                key.lower(): value for key, value in content.get("Metadata", {}).items()
+            }
+            if metadata and "symlink_to" in metadata:
+                islnk = True
+                if follow_symlinks:
+                    s3_url = metadata["symlink_to"]
+                    bucket, key = parse_s3_url(s3_url)
+                    content = self._client.head_object(Bucket=bucket, Key=key)
+            return StatResult(
+                islnk=islnk,
+                size=content["ContentLength"],
+                mtime=content["LastModified"].timestamp(),
+                extra=content,
+            )
+
     def stat(self, follow_symlinks=True) -> StatResult:
         """
         Get StatResult of s3_url file, including file size and mtime,
@@ -2389,36 +2422,19 @@ class S3Path(URIPath):
         :returns: StatResult
         :raises: S3FileNotFoundError, S3BucketNotFoundError
         """
-        islnk = False
         bucket, key = parse_s3_url(self.path_with_protocol)
         if not bucket:
             raise S3BucketNotFoundError(
                 "Empty bucket name: %r" % self.path_with_protocol
             )
 
-        if not self.is_file():
+        if not key or key.endswith("/"):
             return self._get_dir_stat()
 
-        client = self._client
-        with raise_s3_error(self.path_with_protocol):
-            content = client.head_object(Bucket=bucket, Key=key)
-            if "Metadata" in content:
-                metadata = dict(
-                    (key.lower(), value) for key, value in content["Metadata"].items()
-                )
-                if metadata and "symlink_to" in metadata:
-                    islnk = True
-                    if islnk and follow_symlinks:
-                        s3_url = metadata["symlink_to"]
-                        bucket, key = parse_s3_url(s3_url)
-                        content = client.head_object(Bucket=bucket, Key=key)
-            stat_record = StatResult(
-                islnk=islnk,
-                size=content["ContentLength"],
-                mtime=content["LastModified"].timestamp(),
-                extra=content,
-            )
-        return stat_record
+        try:
+            return self._get_file_stat(follow_symlinks=follow_symlinks)
+        except S3FileNotFoundError:
+            return self._get_dir_stat()
 
     def unlink(self, missing_ok: bool = False) -> None:
         """
@@ -2563,7 +2579,7 @@ class S3Path(URIPath):
         src_bucket, src_key = parse_s3_url(src_url)
         dst_bucket, dst_key = parse_s3_url(dst_url)
         if dst_bucket == src_bucket and src_key.rstrip("/") == dst_key.rstrip("/"):
-            raise SameFileError(f"'{src_url}' and '{dst_url}' are the same file")
+            raise SameFileError("%r and %r are the same file" % (src_url, dst_url))
 
         if not src_bucket:
             raise S3BucketNotFoundError("Empty bucket name: %r" % src_url)
@@ -2580,7 +2596,7 @@ class S3Path(URIPath):
                 pass
 
         try:
-            with raise_s3_error(f"'{src_url}' or '{dst_url}'"):
+            with raise_s3_error("%r or %r" % (src_url, dst_url)):
                 self._client.copy(
                     {"Bucket": src_bucket, "Key": src_key},
                     Bucket=dst_bucket,

--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -427,12 +427,15 @@ class WebdavPath(URIPath):
         def create_generator() -> Iterator[FileEntry]:
             if not has_magic(glob_path):
                 path_obj = self.from_path(glob_path)
-                if path_obj.exists():
-                    yield FileEntry(
-                        path_obj.name,
-                        path_obj.path_with_protocol,
-                        path_obj.stat(),
-                    )
+                try:
+                    stat = path_obj.stat()
+                except FileNotFoundError:
+                    return
+                yield FileEntry(
+                    path_obj.name,
+                    path_obj.path_with_protocol,
+                    stat,
+                )
                 return
 
             remote_path = self.from_path(glob_path)._remote_path
@@ -545,7 +548,7 @@ class WebdavPath(URIPath):
         """
         if self.exists():
             if not exist_ok:
-                raise FileExistsError(f"File exists: '{self.path_with_protocol}'")
+                raise FileExistsError("File exists: %r" % self.path_with_protocol)
             return
 
         if parents:
@@ -597,13 +600,19 @@ class WebdavPath(URIPath):
         dst_path = self.from_path(str(dst_path).rstrip("/"))
 
         if self._is_same_backend(dst_path):
+            if not self.exists():
+                raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
             if overwrite:
                 dst_path.remove(missing_ok=True)
             self._client.move(
                 self._remote_path, dst_path._remote_path, overwrite=overwrite
             )
         else:
-            if self.is_dir():
+            try:
+                stat = self.stat()
+            except FileNotFoundError:
+                raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+            if stat.isdir:
                 for file_entry in self.scandir():
                     self.from_path(file_entry.path).rename(
                         dst_path.joinpath(file_entry.name), overwrite=overwrite
@@ -634,13 +643,11 @@ class WebdavPath(URIPath):
         :param missing_ok: if False and target file/directory not exists,
             raise FileNotFoundError
         """
-        if missing_ok and not self.exists():
-            return
         try:
             self._client.clean(self._remote_path)
         except RemoteResourceNotFound:
             if not missing_ok:
-                raise FileNotFoundError(f"No such file: '{self.path_with_protocol}'")
+                raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
 
     def scan(self, missing_ok: bool = True, followlinks: bool = False) -> Iterator[str]:
         """
@@ -665,14 +672,16 @@ class WebdavPath(URIPath):
         """
 
         def create_generator() -> Iterator[FileEntry]:
-            if not self.exists():
+            try:
+                stat = self.stat()
+            except FileNotFoundError:
                 return
 
-            if self.is_file():
+            if not stat.isdir:
                 yield FileEntry(
                     self.name,
                     self.path_with_protocol,
-                    self.stat(),
+                    stat,
                 )
                 return
 
@@ -694,12 +703,14 @@ class WebdavPath(URIPath):
 
         :returns: An iterator contains all contents
         """
-        if not self.exists():
+        try:
+            stat = self.stat()
+        except FileNotFoundError:
             raise FileNotFoundError(
-                f"No such file or directory: '{self.path_with_protocol}'"
+                "No such file or directory: %r" % self.path_with_protocol
             )
-        if not self.is_dir():
-            raise NotADirectoryError(f"Not a directory: '{self.path_with_protocol}'")
+        if not stat.isdir:
+            raise NotADirectoryError("Not a directory: %r" % self.path_with_protocol)
 
         def create_generator():
             for info in _webdav_scandir(self._client, self._remote_path):
@@ -717,7 +728,7 @@ class WebdavPath(URIPath):
             info = _webdav_stat(self._client, self._remote_path)
             return _make_stat(info)
         except RemoteResourceNotFound:
-            raise FileNotFoundError(f"No such file: '{self.path_with_protocol}'")
+            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
 
     def unlink(self, missing_ok: bool = False) -> None:
         """
@@ -732,12 +743,12 @@ class WebdavPath(URIPath):
                 return
             raise
         if stat.isdir:
-            raise IsADirectoryError(f"Is a directory: '{self.path_with_protocol}'")
+            raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
         try:
             self._client.clean(self._remote_path)
         except RemoteResourceNotFound:
             if not missing_ok:
-                raise FileNotFoundError(f"No such file: '{self.path_with_protocol}'")
+                raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
 
     def walk(
         self, followlinks: bool = False
@@ -748,9 +759,11 @@ class WebdavPath(URIPath):
         :param followlinks: Ignored for WebDAV
         :returns: A 3-tuple generator (root, dirs, files)
         """
-        if not self.exists():
+        try:
+            stat = self.stat()
+        except FileNotFoundError:
             return
-        if self.is_file():
+        if not stat.isdir:
             return
 
         stack = [self._remote_path]
@@ -790,7 +803,8 @@ class WebdavPath(URIPath):
         :param followlinks: Ignored for WebDAV
         :returns: md5 of file
         """
-        if self.is_dir():
+        stat = self.stat()
+        if stat.isdir:
             hash_md5 = hashlib.md5()
             for file_name in self.listdir():
                 chunk = (
@@ -866,6 +880,7 @@ class WebdavPath(URIPath):
                 reader = WebdavPrefetchReader(
                     self._remote_path,
                     client=self._client,
+                    content_stat=stat,
                     block_size=block_size,
                     max_buffer_size=max_buffer_size,
                     block_forward=block_forward,
@@ -882,6 +897,7 @@ class WebdavPath(URIPath):
             webdav_client=self._client,
             name=self.path_with_protocol,
             atomic=atomic,
+            content_stat=stat,
         )
 
     def chmod(self, mode: int, *, follow_symlinks: bool = True):
@@ -906,7 +922,7 @@ class WebdavPath(URIPath):
         Remove this directory. The directory must be empty.
         """
         if len(self.listdir()) > 0:
-            raise OSError(f"Directory not empty: '{self.path_with_protocol}'")
+            raise OSError("Directory not empty: %r" % self.path_with_protocol)
         self._client.clean(self._remote_path)
 
     def copy(
@@ -929,7 +945,11 @@ class WebdavPath(URIPath):
         if str(dst_path).endswith("/"):
             raise IsADirectoryError("Is a directory: %r" % dst_path)
 
-        if self.is_dir():
+        try:
+            stat = self.stat()
+        except FileNotFoundError:
+            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+        if stat.isdir:
             raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if not overwrite and self.from_path(dst_path).exists():
@@ -941,11 +961,11 @@ class WebdavPath(URIPath):
         if self._is_same_backend(dst_path):
             if self._remote_path == dst_path._remote_path:
                 raise SameFileError(
-                    f"'{self.path}' and '{dst_path.path}' are the same file"
+                    "%r and %r are the same file" % (self.path, dst_path.path)
                 )
             self._client.copy(self._remote_path, dst_path._remote_path)
             if callback:
-                callback(self.stat().size)
+                callback(stat.size)
         else:
             with self.open("rb") as fsrc:
                 with dst_path.open("wb") as fdst:

--- a/tests/lib/test_webdav_memory_handler.py
+++ b/tests/lib/test_webdav_memory_handler.py
@@ -24,7 +24,7 @@ def client(fs, mocker):
     def fake_webdav_stat(client, path: str) -> Dict:
         return client.info(path)
 
-    def fake_webdav_download_from(client, buff, path: str) -> Dict:
+    def fake_webdav_download_from(client, buff, path: str, *, check=True) -> Dict:
         return client.download_from(buff, path)
 
     mocker.patch(

--- a/tests/s3_utils.py
+++ b/tests/s3_utils.py
@@ -1,0 +1,11 @@
+import boto3
+
+
+def make_moto_s3_client():
+    return boto3.client(
+        "s3",
+        region_name="us-east-1",
+        endpoint_url="https://s3.amazonaws.com",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -50,6 +50,7 @@ from megfile.s3_path import (
 )
 from megfile.utils import process_local, thread_local
 from tests.compat import s3
+from tests.s3_utils import make_moto_s3_client
 
 from . import Any, FakeStatResult, Now
 
@@ -159,7 +160,7 @@ FILE_LIST = [
 @pytest.fixture
 def s3_empty_client(mocker):
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client()
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client
 
@@ -563,6 +564,13 @@ def test_s3_scandir_internal(truncating_client, mocker):
         s3.s3_scandir("s3://bucketA/fileAA")
 
 
+def test_s3_scandir_missing_raises_before_iteration(truncating_client):
+    with pytest.raises(FileNotFoundError):
+        s3.s3_scandir("s3://notExistBucket")
+    with pytest.raises(FileNotFoundError):
+        s3.s3_scandir("s3://bucketA/notExistFile")
+
+
 def test_s3_scandir(truncating_client, mocker):
     mocker.patch("tests.compat.s3.s3_islink", return_value=False)
 
@@ -832,6 +840,15 @@ def test_s3_stat(truncating_client, mocker):
         s3.s3_stat("s3:///notExistFile")
     with pytest.raises(S3FileNotFoundError) as error:
         s3.s3_stat("s3:///bucketA/")
+
+
+def test_s3_stat_file_does_not_repeat_head(s3_empty_client, mocker):
+    s3_empty_client.create_bucket(Bucket="bucket")
+    s3_empty_client.put_object(Bucket="bucket", Key="key", Body=b"value")
+    head_object = mocker.spy(s3_empty_client, "head_object")
+
+    assert s3.s3_stat("s3://bucket/key").size == 5
+    assert head_object.call_count == 1
 
 
 def test_s3_lstat(truncating_client, mocker):
@@ -1544,6 +1561,42 @@ def test_s3_scan_stat(truncating_client, mocker):
 
     with pytest.raises(UnsupportedError) as error:
         s3.s3_scan_stat("s3://")
+
+
+def test_s3_scan_stat_file_does_not_repeat_head(s3_empty_client, mocker):
+    s3_empty_client.create_bucket(Bucket="bucket")
+    s3_empty_client.put_object(Bucket="bucket", Key="key", Body=b"value")
+    head_object = mocker.spy(s3_empty_client, "head_object")
+
+    entries = s3.s3_scan_stat("s3://bucket/key", missing_ok=False)
+    assert head_object.call_count == 1
+    assert [entry.path for entry in entries] == ["s3://bucket/key"]
+    assert head_object.call_count == 1
+
+
+def test_s3_scan_stat_missing_raises_before_iteration(s3_empty_client):
+    s3_empty_client.create_bucket(Bucket="bucket")
+
+    with pytest.raises(FileNotFoundError):
+        s3.s3_scan_stat("s3://bucket/missing", missing_ok=False)
+
+
+def test_s3_glob_stat_non_magic_file_does_not_repeat_head(s3_empty_client, mocker):
+    s3_empty_client.create_bucket(Bucket="bucket")
+    s3_empty_client.put_object(Bucket="bucket", Key="key", Body=b"value")
+    head_object = mocker.spy(s3_empty_client, "head_object")
+
+    entries = s3.s3_glob_stat("s3://bucket/key", missing_ok=False)
+    assert head_object.call_count == 1
+    assert [entry.path for entry in entries] == ["s3://bucket/key"]
+    assert head_object.call_count == 1
+
+
+def test_s3_glob_stat_missing_raises_before_iteration(s3_empty_client):
+    s3_empty_client.create_bucket(Bucket="bucket")
+
+    with pytest.raises(FileNotFoundError):
+        s3.s3_glob_stat("s3://bucket/missing", missing_ok=False)
 
 
 def test_s3_path_join():
@@ -3259,7 +3312,7 @@ def s3_empty_client_with_patch_for_has_bucket(mocker):
         raise botocore.exceptions.ClientError({"Error": {"Code": "403"}}, "head_bucket")
 
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client()
         client.head_bucket = head_bucket_without_permission
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client
@@ -3754,7 +3807,7 @@ def error_client(mocker):
     from megfile.errors import patch_method
 
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client()
 
         def _make_request(*args, **kwargs):
             from botocore.exceptions import ClientError

--- a/tests/test_s3_fast_list.py
+++ b/tests/test_s3_fast_list.py
@@ -1,15 +1,15 @@
-import boto3
 import pytest
 from moto import mock_aws
 
 from megfile.s3_path import _s3_fast_list_objects_recursive
+from tests.s3_utils import make_moto_s3_client
 
 
 @pytest.fixture
 def s3_empty_client(mocker):
     """Create an empty S3 client with moto"""
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client()
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
 
         # Use mocker.spy to track list_objects_v2 calls

--- a/tests/test_smart.py
+++ b/tests/test_smart.py
@@ -2,7 +2,6 @@ import os
 from io import BytesIO, StringIO
 from pathlib import Path
 
-import boto3
 import pytest
 from mock import patch
 from moto import mock_aws
@@ -13,6 +12,7 @@ from megfile.errors import S3UnknownError
 from megfile.interfaces import Access, FileEntry, StatResult
 from megfile.s3_path import _s3_binary_mode
 from megfile.smart_path import SmartPath
+from tests.s3_utils import make_moto_s3_client
 
 
 @pytest.fixture
@@ -26,7 +26,7 @@ BUCKET = "bucket"
 @pytest.fixture
 def s3_empty_client(mocker):
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client()
         client.create_bucket(Bucket=BUCKET)
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client

--- a/tests/test_smart_path.py
+++ b/tests/test_smart_path.py
@@ -1,7 +1,6 @@
 import os
 import stat
 
-import boto3
 import pytest
 from mock import PropertyMock, patch
 from moto import mock_aws
@@ -26,6 +25,7 @@ from megfile.smart_path import (
 )
 from megfile.stdio_path import StdioPath
 from megfile.webdav_path import WebdavPath, WebdavsPath
+from tests.s3_utils import make_moto_s3_client
 
 from .test_sftp import sftp_mocker  # noqa: F401
 
@@ -61,7 +61,7 @@ BUCKET = "bucket"
 @pytest.fixture
 def s3_empty_client(mocker):
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client()
         client.create_bucket(Bucket=BUCKET)
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client

--- a/tests/test_smart_purepath.py
+++ b/tests/test_smart_purepath.py
@@ -1,7 +1,6 @@
 import os
 from typing import Generator
 
-import boto3
 import pytest
 from mock import PropertyMock, patch
 from moto import mock_aws
@@ -11,6 +10,7 @@ from megfile.lib.compat import fspath
 from megfile.pathlike import StatResult
 from megfile.s3_path import S3Path
 from megfile.smart_path import SmartPath
+from tests.s3_utils import make_moto_s3_client
 
 from . import FakeStatResult, Now
 
@@ -20,7 +20,7 @@ BUCKET = "bucket"
 @pytest.fixture
 def s3_empty_client(mocker):
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client()
         client.create_bucket(Bucket=BUCKET)
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1,6 +1,7 @@
 import io
 import os
 import shutil
+from collections import defaultdict
 from datetime import datetime
 from typing import Dict, Iterator, List
 
@@ -12,7 +13,7 @@ from webdav3.exceptions import (
 
 from megfile import smart_copy
 from megfile.errors import SameFileError
-from megfile.webdav_path import _patch_execute_request
+from megfile.webdav_path import _patch_execute_request, thread_local
 from tests.compat import webdav
 
 from .test_http import FakeResponse  # noqa: F401
@@ -25,6 +26,10 @@ class FakeWebdavClient:
 
     def __init__(self, options: dict = {}):
         self.options = options
+        self.info_calls = defaultdict(int)
+        self.clean_calls = defaultdict(int)
+        self.check_calls = defaultdict(int)
+        self.is_dir_calls = defaultdict(int)
 
     def _relative_path(self, path: str) -> str:
         # XXX: pyfakefs not work in python3.14 when path is absolute
@@ -39,11 +44,13 @@ class FakeWebdavClient:
     def check(self, path: str) -> bool:
         """Check if path exists"""
         path = self._relative_path(path)
+        self.check_calls[path] += 1
         return os.path.exists(path)
 
     def is_dir(self, path: str) -> bool:
         """Check if path is a directory"""
         path = self._relative_path(path)
+        self.is_dir_calls[path] += 1
         return os.path.isdir(path)
 
     def list(self, path: str, get_info: bool = False) -> List:
@@ -70,6 +77,7 @@ class FakeWebdavClient:
     def info(self, path: str) -> Dict:
         """Get file/directory info"""
         path = self._relative_path(path)
+        self.info_calls[path] += 1
         if not os.path.exists(path):
             raise RemoteResourceNotFound(path)
 
@@ -89,6 +97,7 @@ class FakeWebdavClient:
     def clean(self, path: str):
         """Remove file or directory"""
         path = self._relative_path(path)
+        self.clean_calls[path] += 1
         if not os.path.exists(path):
             raise RemoteResourceNotFound(path)
 
@@ -143,6 +152,7 @@ def webdav_mocker(fs, mocker):
     """Mock WebDAV client to use local filesystem"""
 
     client = FakeWebdavClient()
+    thread_local._data.clear()
 
     def fake_get_webdav_client(hostname, username=None, password=None, token=None):
         return client
@@ -156,7 +166,7 @@ def webdav_mocker(fs, mocker):
                 yield from fake_webdav_scan(client, info["path"])
             yield info
 
-    def fake_webdav_download_from(client, buff, path: str) -> Dict:
+    def fake_webdav_download_from(client, buff, path: str, *, check=True) -> Dict:
         return client.download_from(buff, path)
 
     mocker.patch(
@@ -172,6 +182,7 @@ def webdav_mocker(fs, mocker):
         side_effect=fake_webdav_download_from,
     )
     yield client
+    thread_local._data.clear()
 
 
 def test_is_webdav():
@@ -392,13 +403,21 @@ def test_webdav_move(webdav_mocker):
 
 
 def test_webdav_open(webdav_mocker):
+    client = webdav_mocker
+
     webdav.webdav_makedirs("webdav://host/A")
 
     with webdav.webdav_open("webdav://host/A/test", "w") as f:
         f.write("test")
 
+    client.info_calls.clear()
+    client.check_calls.clear()
+    client.is_dir_calls.clear()
     with webdav.webdav_open("webdav://host/A/test", "r") as f:
         assert f.read() == "test"
+    assert client.info_calls["./A/test"] == 1
+    assert sum(client.check_calls.values()) == 0
+    assert sum(client.is_dir_calls.values()) == 0
 
     with webdav.webdav_open("webdav://host/A/test", "rb") as f:
         assert f.read() == b"test"
@@ -496,6 +515,32 @@ def test_webdav_unlink(webdav_mocker):
     assert webdav.webdav_exists("webdav://host/A/test") is True
 
 
+def test_webdav_non_mutating_operations_do_not_repeat_stat(webdav_mocker):
+    client = webdav_mocker
+
+    webdav.webdav_makedirs("webdav://host/A")
+    with webdav.webdav_open("webdav://host/A/file.txt", "w") as f:
+        f.write("test")
+
+    client.info_calls.clear()
+    assert [
+        entry.path for entry in webdav.webdav_scan_stat("webdav://host/A/file.txt")
+    ] == ["webdav://host/A/file.txt"]
+    assert client.info_calls["./A/file.txt"] == 1
+
+    client.info_calls.clear()
+    assert [entry.name for entry in webdav.webdav_scandir("webdav://host/A")] == [
+        "file.txt"
+    ]
+    assert client.info_calls["./A"] == 1
+
+    client.info_calls.clear()
+    assert [
+        entry.path for entry in webdav.webdav_glob_stat("webdav://host/A/file.txt")
+    ] == ["webdav://host/A/file.txt"]
+    assert client.info_calls["./A/file.txt"] == 1
+
+
 def test_webdav_walk(webdav_mocker):
     webdav.webdav_makedirs("webdav://host/A")
     webdav.webdav_makedirs("webdav://host/A/a")
@@ -550,6 +595,8 @@ def test_webdav_rmdir(webdav_mocker):
 
 
 def test_webdav_copy(webdav_mocker):
+    client = webdav_mocker
+
     webdav.webdav_makedirs("webdav://host/A")
     with webdav.webdav_open("webdav://host/A/1.json", "w") as f:
         f.write("1.json")
@@ -557,11 +604,13 @@ def test_webdav_copy(webdav_mocker):
     def callback(length):
         assert length == len("1.json")
 
+    client.info_calls.clear()
     webdav.webdav_copy(
         "webdav://host/A/1.json",
         "webdav://host/A2/1.json.bak",
         callback=callback,
     )
+    assert client.info_calls["./A/1.json"] == 1
 
     assert (
         webdav.webdav_stat("webdav://host/A/1.json").size

--- a/tests/timeout/s3_pipe_handler_read_without_close.py
+++ b/tests/timeout/s3_pipe_handler_read_without_close.py
@@ -3,17 +3,17 @@
 # To test if it will cause deadlock that
 # exiting Python process without calling close on S3PipeHandler
 
-import boto3
 from moto import mock_aws
 
 from megfile.lib.s3_pipe_handler import S3PipeHandler
+from tests.s3_utils import make_moto_s3_client
 
 BUCKET = "bucket"
 KEY = "key"
 CONTENT = b" " * 10000000  # 10MB
 
 with mock_aws():
-    client = boto3.client("s3")
+    client = make_moto_s3_client()
     client.create_bucket(Bucket=BUCKET)
     client.put_object(Bucket=BUCKET, Key=KEY, Body=CONTENT)
     reader1 = S3PipeHandler(BUCKET, KEY, "rb", s3_client=client)

--- a/tests/timeout/s3_pipe_handler_write_without_close.py
+++ b/tests/timeout/s3_pipe_handler_write_without_close.py
@@ -3,17 +3,17 @@
 # To test if it will cause deadlock that
 # exiting Python process without calling close on S3PipeHandler
 
-import boto3
 from moto import mock_aws
 
 from megfile.lib.s3_pipe_handler import S3PipeHandler
+from tests.s3_utils import make_moto_s3_client
 
 BUCKET = "bucket"
 KEY = "key"
 CONTENT = b" "
 
 with mock_aws():
-    client = boto3.client("s3")
+    client = make_moto_s3_client()
     client.create_bucket(Bucket=BUCKET)
     writer1 = S3PipeHandler(BUCKET, KEY, "wb", s3_client=client)
     writer2 = S3PipeHandler(BUCKET, KEY, "wb", s3_client=client)


### PR DESCRIPTION
## Summary
- reuse WebDAV stat results across scan/scandir/glob/open/copy paths and pass cached stat into readers/handlers
- reduce S3 file stat duplication so stat(), scan_stat(file), and non-magic glob_stat(file) avoid repeated HEAD requests
- keep S3 scandir/scan_stat/glob_stat missing-path errors eager where expected, while preserving empty bucket scandir behavior
- make moto S3 test clients use a fixed AWS endpoint and dummy credentials so custom local endpoints do not leak to real OSS

## Tests
- make style_check
- pytest tests/test_webdav.py tests/lib/test_webdav_memory_handler.py tests/lib/test_webdav_prefetch_reader.py tests/lib/test_http_prefetch_reader.py tests/lib/test_s3_memory_handler.py tests/lib/test_s3_prefetch_reader.py -q
- pytest tests/test_s3.py::test_s3_stat tests/test_s3.py::test_s3_scandir_internal tests/test_s3.py::test_s3_scandir tests/test_s3.py::test_s3_scan_stat tests/lib/test_s3_memory_handler.py tests/lib/test_s3_prefetch_reader.py -q
- pytest tests/test_smart.py::test_smart_unlink tests/test_smart.py::test_smart_copy -q