### PR TITLE
test: isolate moto S3 clients from local endpoints

### DIFF
--- a/tests/s3_utils.py
+++ b/tests/s3_utils.py
@@ -1,0 +1,15 @@
+import boto3
+
+
+def make_moto_s3_client(monkeypatch=None):
+    if monkeypatch is not None:
+        monkeypatch.setenv("AWS_CONFIG_FILE", "/dev/null")
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
+
+    return boto3.client(
+        "s3",
+        region_name="us-east-1",
+        endpoint_url="https://s3.amazonaws.com",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -50,6 +50,7 @@ from megfile.s3_path import (
 )
 from megfile.utils import process_local, thread_local
 from tests.compat import s3
+from tests.s3_utils import make_moto_s3_client
 
 from . import Any, FakeStatResult, Now
 
@@ -157,9 +158,9 @@ FILE_LIST = [
 
 
 @pytest.fixture
-def s3_empty_client(mocker):
+def s3_empty_client(mocker, monkeypatch):
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client(monkeypatch)
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client
 
@@ -3254,12 +3255,12 @@ def test_group_s3path_by_prefix():
 
 
 @pytest.fixture
-def s3_empty_client_with_patch_for_has_bucket(mocker):
+def s3_empty_client_with_patch_for_has_bucket(mocker, monkeypatch):
     def head_bucket_without_permission(*args, **kwargs):
         raise botocore.exceptions.ClientError({"Error": {"Code": "403"}}, "head_bucket")
 
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client(monkeypatch)
         client.head_bucket = head_bucket_without_permission
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client
@@ -3750,11 +3751,11 @@ def test_s3_atomic(s3_empty_client):
 
 
 @pytest.fixture
-def error_client(mocker):
+def error_client(mocker, monkeypatch):
     from megfile.errors import patch_method
 
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client(monkeypatch)
 
         def _make_request(*args, **kwargs):
             from botocore.exceptions import ClientError

--- a/tests/test_s3_fast_list.py
+++ b/tests/test_s3_fast_list.py
@@ -1,15 +1,15 @@
-import boto3
 import pytest
 from moto import mock_aws
 
 from megfile.s3_path import _s3_fast_list_objects_recursive
+from tests.s3_utils import make_moto_s3_client
 
 
 @pytest.fixture
-def s3_empty_client(mocker):
+def s3_empty_client(mocker, monkeypatch):
     """Create an empty S3 client with moto"""
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client(monkeypatch)
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
 
         # Use mocker.spy to track list_objects_v2 calls

--- a/tests/test_smart.py
+++ b/tests/test_smart.py
@@ -2,7 +2,6 @@ import os
 from io import BytesIO, StringIO
 from pathlib import Path
 
-import boto3
 import pytest
 from mock import patch
 from moto import mock_aws
@@ -13,6 +12,7 @@ from megfile.errors import S3UnknownError
 from megfile.interfaces import Access, FileEntry, StatResult
 from megfile.s3_path import _s3_binary_mode
 from megfile.smart_path import SmartPath
+from tests.s3_utils import make_moto_s3_client
 
 
 @pytest.fixture
@@ -24,9 +24,9 @@ BUCKET = "bucket"
 
 
 @pytest.fixture
-def s3_empty_client(mocker):
+def s3_empty_client(mocker, monkeypatch):
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client(monkeypatch)
         client.create_bucket(Bucket=BUCKET)
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client

--- a/tests/test_smart_path.py
+++ b/tests/test_smart_path.py
@@ -1,7 +1,6 @@
 import os
 import stat
 
-import boto3
 import pytest
 from mock import PropertyMock, patch
 from moto import mock_aws
@@ -26,6 +25,7 @@ from megfile.smart_path import (
 )
 from megfile.stdio_path import StdioPath
 from megfile.webdav_path import WebdavPath, WebdavsPath
+from tests.s3_utils import make_moto_s3_client
 
 from .test_sftp import sftp_mocker  # noqa: F401
 
@@ -59,9 +59,9 @@ BUCKET = "bucket"
 
 
 @pytest.fixture
-def s3_empty_client(mocker):
+def s3_empty_client(mocker, monkeypatch):
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client(monkeypatch)
         client.create_bucket(Bucket=BUCKET)
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client

--- a/tests/test_smart_purepath.py
+++ b/tests/test_smart_purepath.py
@@ -1,7 +1,6 @@
 import os
 from typing import Generator
 
-import boto3
 import pytest
 from mock import PropertyMock, patch
 from moto import mock_aws
@@ -11,6 +10,7 @@ from megfile.lib.compat import fspath
 from megfile.pathlike import StatResult
 from megfile.s3_path import S3Path
 from megfile.smart_path import SmartPath
+from tests.s3_utils import make_moto_s3_client
 
 from . import FakeStatResult, Now
 
@@ -18,9 +18,9 @@ BUCKET = "bucket"
 
 
 @pytest.fixture
-def s3_empty_client(mocker):
+def s3_empty_client(mocker, monkeypatch):
     with mock_aws():
-        client = boto3.client("s3")
+        client = make_moto_s3_client(monkeypatch)
         client.create_bucket(Bucket=BUCKET)
         mocker.patch("megfile.s3_path.get_s3_client", return_value=client)
         yield client

--- a/tests/timeout/s3_pipe_handler_read_without_close.py
+++ b/tests/timeout/s3_pipe_handler_read_without_close.py
@@ -3,17 +3,17 @@
 # To test if it will cause deadlock that
 # exiting Python process without calling close on S3PipeHandler
 
-import boto3
 from moto import mock_aws
 
 from megfile.lib.s3_pipe_handler import S3PipeHandler
+from tests.s3_utils import make_moto_s3_client
 
 BUCKET = "bucket"
 KEY = "key"
 CONTENT = b" " * 10000000  # 10MB
 
 with mock_aws():
-    client = boto3.client("s3")
+    client = make_moto_s3_client()
     client.create_bucket(Bucket=BUCKET)
     client.put_object(Bucket=BUCKET, Key=KEY, Body=CONTENT)
     reader1 = S3PipeHandler(BUCKET, KEY, "rb", s3_client=client)

--- a/tests/timeout/s3_pipe_handler_write_without_close.py
+++ b/tests/timeout/s3_pipe_handler_write_without_close.py
@@ -3,17 +3,17 @@
 # To test if it will cause deadlock that
 # exiting Python process without calling close on S3PipeHandler
 
-import boto3
 from moto import mock_aws
 
 from megfile.lib.s3_pipe_handler import S3PipeHandler
+from tests.s3_utils import make_moto_s3_client
 
 BUCKET = "bucket"
 KEY = "key"
 CONTENT = b" "
 
 with mock_aws():
-    client = boto3.client("s3")
+    client = make_moto_s3_client()
     client.create_bucket(Bucket=BUCKET)
     writer1 = S3PipeHandler(BUCKET, KEY, "wb", s3_client=client)
     writer2 = S3PipeHandler(BUCKET, KEY, "wb", s3_client=client)


### PR DESCRIPTION
## Context

This fixes a test isolation issue that appears when the local default AWS profile has a custom S3/OSS endpoint configured. On this dev box, plain boto3.client("s3") inherits that endpoint from the default profile. With newer moto behavior, requests to custom endpoints may not be intercepted by moto, so tests can leak out and hit the real OSS endpoint, failing with errors such as InvalidAccessKeyId.

The current megfile CI did not trigger this because its default profile does not configure a custom endpoint. This PR makes the tests independent of the developer/CI AWS profile configuration.

## Summary

- add a shared moto S3 client helper with fixed AWS endpoint and dummy credentials
- clear AWS config/credentials files from pytest fixtures via monkeypatch, matching the isolation used in megfile-vibe
- use the helper in S3-related tests and timeout scripts so local AWS/OSS endpoint config cannot leak into moto tests

## Tests

- make style_check
- pytest tests/lib/test_s3_memory_handler.py tests/lib/test_s3_prefetch_reader.py tests/test_s3.py::test_s3_hasbucket tests/test_s3.py::test_error -q
