### PR TITLE
refactor: pass content stat through readers

### DIFF
--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -631,6 +631,11 @@ class HdfsPath(URIPath):
 
         with raise_hdfs_error(self.path_with_protocol):
             if mode in ("r", "rb"):
+                stat = self.stat()
+                if stat.isdir:
+                    raise IsADirectoryError(
+                        "Is a directory: %r" % self.path_with_protocol
+                    )
                 file_obj = HdfsPrefetchReader(
                     hdfs_path=self.path_without_protocol,
                     client=self._client,
@@ -640,6 +645,7 @@ class HdfsPath(URIPath):
                     block_forward=block_forward,
                     max_retries=HDFS_MAX_RETRY_TIMES,
                     max_workers=max_workers,
+                    content_stat=stat,
                 )
                 if _is_pickle(file_obj):
                     file_obj = io.BufferedReader(file_obj)  # type: ignore

--- a/megfile/http_path.py
+++ b/megfile/http_path.py
@@ -129,6 +129,30 @@ def is_http(path: PathLike) -> bool:
     return scheme == "http" or scheme == "https"
 
 
+def _make_stat(headers) -> StatResult:
+    size = headers.get("Content-Length")
+    if size:
+        size = int(size)
+    else:
+        size = 0
+
+    last_modified = headers.get("Last-Modified")
+    if last_modified:
+        last_modified = time.mktime(
+            time.strptime(last_modified, "%a, %d %b %Y %H:%M:%S %Z")
+        )
+    else:
+        last_modified = 0.0
+
+    return StatResult(
+        size=size,
+        mtime=last_modified,
+        isdir=False,
+        islnk=False,
+        extra=headers,
+    )
+
+
 @SmartPath.register
 class HttpPath(URIPath):
     protocol = "http"
@@ -189,7 +213,8 @@ class HttpPath(URIPath):
             raise translate_http_error(error, self.path_with_protocol)
 
         headers = response.headers
-        content_size = int(headers.get("Content-Length", 0))
+        content_stat = _make_stat(headers)
+        content_size = content_stat.size
         if (
             headers.get("Accept-Ranges") == "bytes"
             and content_size >= block_size * 2
@@ -201,6 +226,7 @@ class HttpPath(URIPath):
                 self,
                 session=self.session,
                 content_size=content_size,
+                content_stat=content_stat,
                 block_size=block_size,
                 max_buffer_size=max_buffer_size,
                 block_forward=block_forward,
@@ -235,27 +261,7 @@ class HttpPath(URIPath):
         except Exception as error:
             raise translate_http_error(error, self.path_with_protocol)
 
-        size = headers.get("Content-Length")
-        if size:
-            size = int(size)
-        else:
-            size = 0
-
-        last_modified = headers.get("Last-Modified")
-        if last_modified:
-            last_modified = time.mktime(
-                time.strptime(last_modified, "%a, %d %b %Y %H:%M:%S %Z")
-            )
-        else:
-            last_modified = 0.0
-
-        return StatResult(
-            size=size,
-            mtime=last_modified,
-            isdir=False,
-            islnk=False,
-            extra=headers,
-        )
+        return _make_stat(headers)
 
     def getsize(self, follow_symlinks: bool = False) -> int:
         """

--- a/megfile/lib/base_memory_handler.py
+++ b/megfile/lib/base_memory_handler.py
@@ -4,6 +4,7 @@ from io import BytesIO, UnsupportedOperation
 from typing import Iterable, List, Optional
 
 from megfile.interfaces import Readable, Seekable, Writable
+from megfile.pathlike import UNKNOWN_STAT, StatResult
 
 
 class BaseMemoryHandler(Readable[bytes], Seekable, Writable[bytes], ABC):
@@ -12,8 +13,10 @@ class BaseMemoryHandler(Readable[bytes], Seekable, Writable[bytes], ABC):
         mode: str,
         *,
         atomic: bool = False,
+        content_stat=UNKNOWN_STAT,
     ):
         self._mode = mode
+        self._content_stat = content_stat
 
         if mode not in ("rb", "wb", "ab", "rb+", "wb+", "ab+"):
             raise ValueError("unacceptable mode: %r" % mode)
@@ -87,6 +90,17 @@ class BaseMemoryHandler(Readable[bytes], Seekable, Writable[bytes], ABC):
 
     @abstractmethod
     def _upload_fileobj(self):
+        pass
+
+    def _file_exists(self) -> bool:
+        if isinstance(self._content_stat, StatResult):
+            return self._content_stat.is_file()
+        if self._content_stat is None:
+            return False
+        return self._file_exists_from_remote()
+
+    @abstractmethod
+    def _file_exists_from_remote(self) -> bool:
         pass
 
     def _close(self, need_upload: bool = True):

--- a/megfile/lib/base_prefetch_reader.py
+++ b/megfile/lib/base_prefetch_reader.py
@@ -15,6 +15,7 @@ from megfile.config import (
     READER_MAX_BUFFER_SIZE,
 )
 from megfile.interfaces import Readable, Seekable
+from megfile.pathlike import UNKNOWN_STAT, StatResult
 from megfile.utils import ProcessLocal, process_local
 
 _logger = get_logger(__name__)
@@ -36,8 +37,10 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
         block_forward: Optional[int] = None,
         max_retries: int = DEFAULT_MAX_RETRY_TIMES,
         max_workers: Optional[int] = None,
+        content_stat=UNKNOWN_STAT,
         **kwargs,
     ):
+        self._content_stat = content_stat
         self._is_global_executor = False
         if max_workers is None:
             self._executor = process_local(
@@ -89,8 +92,13 @@ class BasePrefetchReader(Readable[bytes], Seekable, ABC):
 
         _logger.debug("open file: %r, mode: %s" % (self.name, self.mode))
 
-    @abstractmethod
     def _get_content_size(self):
+        if isinstance(self._content_stat, StatResult):
+            return int(self._content_stat.size)
+        return self._get_content_size_from_remote()
+
+    @abstractmethod
+    def _get_content_size_from_remote(self):
         pass  # pragma: no cover
 
     @property

--- a/megfile/lib/hdfs_prefetch_reader.py
+++ b/megfile/lib/hdfs_prefetch_reader.py
@@ -8,6 +8,7 @@ from megfile.config import (
 )
 from megfile.errors import raise_hdfs_error
 from megfile.lib.base_prefetch_reader import BasePrefetchReader
+from megfile.pathlike import UNKNOWN_STAT
 
 
 class HdfsPrefetchReader(BasePrefetchReader):
@@ -32,6 +33,7 @@ class HdfsPrefetchReader(BasePrefetchReader):
         max_retries: int = HDFS_MAX_RETRY_TIMES,
         max_workers: Optional[int] = None,
         profile_name: Optional[str] = None,
+        content_stat=UNKNOWN_STAT,
     ):
         self._path = hdfs_path
         self._client = client
@@ -43,9 +45,10 @@ class HdfsPrefetchReader(BasePrefetchReader):
             block_forward=block_forward,
             max_retries=max_retries,
             max_workers=max_workers,
+            content_stat=content_stat,
         )
 
-    def _get_content_size(self):
+    def _get_content_size_from_remote(self):
         with raise_hdfs_error(self._path):
             return self._client.status(self._path)["length"]
 

--- a/megfile/lib/http_prefetch_reader.py
+++ b/megfile/lib/http_prefetch_reader.py
@@ -16,7 +16,7 @@ from megfile.errors import (
 )
 from megfile.lib.base_prefetch_reader import BasePrefetchReader
 from megfile.lib.compat import fspath
-from megfile.pathlike import PathLike
+from megfile.pathlike import UNKNOWN_STAT, PathLike
 
 DEFAULT_TIMEOUT = (60, 60 * 60 * 24)
 
@@ -40,6 +40,7 @@ class HttpPrefetchReader(BasePrefetchReader):
         *,
         session: Optional[requests.Session] = None,
         content_size: Optional[int] = None,
+        content_stat=UNKNOWN_STAT,
         block_size: int = READER_BLOCK_SIZE,
         max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
@@ -56,9 +57,10 @@ class HttpPrefetchReader(BasePrefetchReader):
             block_forward=block_forward,
             max_retries=max_retries,
             max_workers=max_workers,
+            content_stat=content_stat,
         )
 
-    def _get_content_size(self) -> int:
+    def _get_content_size_from_remote(self) -> int:
         if self._content_size is not None:
             return self._content_size
 

--- a/megfile/lib/s3_cached_handler.py
+++ b/megfile/lib/s3_cached_handler.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from megfile.errors import translate_fs_error, translate_s3_error
 from megfile.lib.s3_memory_handler import S3MemoryHandler
+from megfile.pathlike import UNKNOWN_STAT
 from megfile.utils import generate_cache_path
 
 
@@ -24,6 +25,7 @@ class S3CachedHandler(S3MemoryHandler):
         self._mode = mode
         self._client = s3_client
         self._profile_name = profile_name
+        self._content_stat = UNKNOWN_STAT
 
         if mode not in ("rb", "wb", "ab", "rb+", "wb+", "ab+"):
             raise ValueError("unacceptable mode: %r" % mode)

--- a/megfile/lib/s3_memory_handler.py
+++ b/megfile/lib/s3_memory_handler.py
@@ -35,7 +35,7 @@ class S3MemoryHandler(BaseMemoryHandler):
     def _translate_error(self, error: Exception):
         return translate_s3_error(error, self.name)
 
-    def _file_exists(self) -> bool:
+    def _file_exists_from_remote(self) -> bool:
         try:
             self._client.head_object(Bucket=self._bucket, Key=self._key)
         except Exception as error:

--- a/megfile/lib/s3_prefetch_reader.py
+++ b/megfile/lib/s3_prefetch_reader.py
@@ -62,7 +62,7 @@ class S3PrefetchReader(BasePrefetchReader):
             max_workers=max_workers,
         )
 
-    def _get_content_size(self):
+    def _get_content_size_from_remote(self):
         if self._block_capacity <= 0 or READER_LAZY_PREFETCH:
             response = self._client.head_object(Bucket=self._bucket, Key=self._key)
             self._content_etag = response.get("ETag")

--- a/megfile/lib/webdav_memory_handler.py
+++ b/megfile/lib/webdav_memory_handler.py
@@ -8,6 +8,7 @@ from webdav3.exceptions import (
 )
 
 from megfile.lib.base_memory_handler import BaseMemoryHandler
+from megfile.pathlike import UNKNOWN_STAT
 
 
 def _webdav_stat(client: WebdavClient, remote_path: str):
@@ -26,13 +27,14 @@ def _webdav_stat(client: WebdavClient, remote_path: str):
 
 
 @wrap_connection_error
-def _webdav_download_from(client: WebdavClient, buff, remote_path):
+def _webdav_download_from(client: WebdavClient, buff, remote_path, *, check=True):
     urn = Urn(remote_path)
-    if client.is_dir(urn.path()):
-        raise OptionNotValid(name="remote_path", value=remote_path)
+    if check:
+        if client.is_dir(urn.path()):
+            raise OptionNotValid(name="remote_path", value=remote_path)
 
-    if not client.check(urn.path()):
-        raise RemoteResourceNotFound(urn.path())
+        if not client.check(urn.path()):
+            raise RemoteResourceNotFound(urn.path())
 
     response = client.execute_request(action="download", path=urn.quote())
 
@@ -49,17 +51,18 @@ class WebdavMemoryHandler(BaseMemoryHandler):
         webdav_client: WebdavClient,
         name: str,
         atomic: bool = False,
+        content_stat=UNKNOWN_STAT,
     ):
         self._remote_path = remote_path
         self._client = webdav_client
         self._name = name
-        super().__init__(mode=mode, atomic=atomic)
+        super().__init__(mode=mode, atomic=atomic, content_stat=content_stat)
 
     @property
     def name(self) -> str:
         return self._name
 
-    def _file_exists(self) -> bool:
+    def _file_exists_from_remote(self) -> bool:
         try:
             return not _webdav_stat(self._client, self._remote_path)["isdir"]
         except RemoteResourceNotFound:
@@ -71,7 +74,12 @@ class WebdavMemoryHandler(BaseMemoryHandler):
         if not need_download:
             return
         # directly download to the file handle
-        _webdav_download_from(self._client, self._fileobj, self._remote_path)
+        _webdav_download_from(
+            self._client,
+            self._fileobj,
+            self._remote_path,
+            check=self._content_stat is UNKNOWN_STAT,
+        )
         if self._mode[0] == "r":
             self.seek(0, os.SEEK_SET)
 

--- a/megfile/lib/webdav_prefetch_reader.py
+++ b/megfile/lib/webdav_prefetch_reader.py
@@ -16,6 +16,7 @@ from megfile.errors import (
 )
 from megfile.lib.base_prefetch_reader import BasePrefetchReader
 from megfile.lib.webdav_memory_handler import _webdav_stat
+from megfile.pathlike import UNKNOWN_STAT
 
 DEFAULT_TIMEOUT = (60, 60 * 60 * 24)
 
@@ -38,6 +39,7 @@ class WebdavPrefetchReader(BasePrefetchReader):
         remote_path: str,
         *,
         client: Optional[WebdavClient] = None,
+        content_stat=UNKNOWN_STAT,
         block_size: int = READER_BLOCK_SIZE,
         max_buffer_size: int = READER_MAX_BUFFER_SIZE,
         block_forward: Optional[int] = None,
@@ -54,9 +56,10 @@ class WebdavPrefetchReader(BasePrefetchReader):
             block_forward=block_forward,
             max_retries=max_retries,
             max_workers=max_workers,
+            content_stat=content_stat,
         )
 
-    def _get_content_size(self) -> int:
+    def _get_content_size_from_remote(self) -> int:
         info = _webdav_stat(self._client, self._remote_path)
         return int(info.get("size") or 0)
 

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -24,6 +24,7 @@ from megfile.lib.fnmatch import _compile_pattern
 from megfile.lib.joinpath import uri_join
 
 Self = TypeVar("Self")
+UNKNOWN_STAT = object()
 
 
 class Access(Enum):

--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -866,6 +866,7 @@ class WebdavPath(URIPath):
                 reader = WebdavPrefetchReader(
                     self._remote_path,
                     client=self._client,
+                    content_stat=stat,
                     block_size=block_size,
                     max_buffer_size=max_buffer_size,
                     block_forward=block_forward,
@@ -882,6 +883,7 @@ class WebdavPath(URIPath):
             webdav_client=self._client,
             name=self.path_with_protocol,
             atomic=atomic,
+            content_stat=stat,
         )
 
     def chmod(self, mode: int, *, follow_symlinks: bool = True):

--- a/tests/lib/test_webdav_memory_handler.py
+++ b/tests/lib/test_webdav_memory_handler.py
@@ -24,7 +24,7 @@ def client(fs, mocker):
     def fake_webdav_stat(client, path: str) -> Dict:
         return client.info(path)
 
-    def fake_webdav_download_from(client, buff, path: str) -> Dict:
+    def fake_webdav_download_from(client, buff, path: str, *, check=True) -> Dict:
         return client.download_from(buff, path)
 
     mocker.patch(

--- a/tests/test_hdfs.py
+++ b/tests/test_hdfs.py
@@ -226,6 +226,11 @@ def test_hdfs_load_from(http_mocker):
     assert hdfs.hdfs_load_from("hdfs://root/b/3.txt").read() == b"333"
 
 
+def test_hdfs_open_dir(http_mocker):
+    with pytest.raises(IsADirectoryError):
+        hdfs.hdfs_open("hdfs://root", "rb")
+
+
 def test_hdfs_move(http_mocker, mocker):
     http_mocker.put(
         "http://127.0.0.1:8000/webhdfs/v1/a?op=RENAME&destination=%2Fb",

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -156,7 +156,7 @@ def webdav_mocker(fs, mocker):
                 yield from fake_webdav_scan(client, info["path"])
             yield info
 
-    def fake_webdav_download_from(client, buff, path: str) -> Dict:
+    def fake_webdav_download_from(client, buff, path: str, *, check=True) -> Dict:
         return client.download_from(buff, path)
 
     mocker.patch(


### PR DESCRIPTION
## Summary
- split the shared `content_stat` reader/handler plumbing out of the previous request-reduction branch
- add `UNKNOWN_STAT` beside `StatResult` and let the shared base reader/handler consume known stat information
- pass internally-known stat information from WebDAV open, HTTP response headers, and HDFS open pre-stat into the selected reader/handler
- add an HDFS read-open directory guard before constructing the prefetch reader
- share HTTP header-to-StatResult parsing through the protocol-local `_make_stat` helper, matching other protocol modules
- avoid exposing `content_stat` on SDK/path APIs or protocol helpers that have no internal caller supplying it
- keep S3 open request behavior out of this PR

## Tests
- `make style_check`
- `pytest tests/lib/test_s3_memory_handler.py tests/lib/test_s3_prefetch_reader.py tests/lib/test_http_prefetch_reader.py tests/lib/test_webdav_memory_handler.py tests/lib/test_webdav_prefetch_reader.py tests/test_webdav.py::test_webdav_open tests/test_http.py -q`
- `python - <<PY ... HdfsPrefetchReader(..., content_stat=StatResult(size=3)) ... PY`
- `pytest tests/test_hdfs.py -q` (blocked locally: missing `requests_mock` fixture in this environment)
- `pytest tests/lib/test_s3_cached_handler.py::test_s3_cached_handler_append tests/lib/test_s3_cached_handler.py::test_s3_cached_handler_mode_ab tests/lib/test_s3_cached_handler.py::test_s3_cached_handler_mode_rbp tests/test_s3.py::test_s3_buffered_open -q` (blocked locally by pyfakefs/moto loader UnknownServiceError before exercising the PR fix)