### PR TITLE
refactor: reuse WebDAV stat checks

### DIFF
--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -634,6 +634,12 @@ class BasePath:
         """Get the status of the path."""
         raise NotImplementedError('method "stat" not implemented: %r' % self)
 
+    def _stat_or_none(self, follow_symlinks=True) -> Optional[StatResult]:
+        try:
+            return self.stat(follow_symlinks=follow_symlinks)
+        except FileNotFoundError:
+            return None
+
     def lstat(self) -> StatResult:
         """
         Like stat() but, if the path points to a symbolic link,

--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -640,7 +640,7 @@ class WebdavPath(URIPath):
             self._client.clean(self._remote_path)
         except RemoteResourceNotFound:
             if not missing_ok:
-                raise FileNotFoundError(f"No such file: '{self.path_with_protocol}'")
+                raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
 
     def scan(self, missing_ok: bool = True, followlinks: bool = False) -> Iterator[str]:
         """
@@ -665,14 +665,15 @@ class WebdavPath(URIPath):
         """
 
         def create_generator() -> Iterator[FileEntry]:
-            if not self.exists():
+            stat = self._stat_or_none()
+            if stat is None:
                 return
 
-            if self.is_file():
+            if stat.is_file():
                 yield FileEntry(
                     self.name,
                     self.path_with_protocol,
-                    self.stat(),
+                    stat,
                 )
                 return
 
@@ -694,11 +695,12 @@ class WebdavPath(URIPath):
 
         :returns: An iterator contains all contents
         """
-        if not self.exists():
+        stat = self._stat_or_none()
+        if stat is None:
             raise FileNotFoundError(
-                f"No such file or directory: '{self.path_with_protocol}'"
+                "No such file or directory: %r" % self.path_with_protocol
             )
-        if not self.is_dir():
+        if not stat.is_dir():
             raise NotADirectoryError(f"Not a directory: '{self.path_with_protocol}'")
 
         def create_generator():
@@ -717,7 +719,7 @@ class WebdavPath(URIPath):
             info = _webdav_stat(self._client, self._remote_path)
             return _make_stat(info)
         except RemoteResourceNotFound:
-            raise FileNotFoundError(f"No such file: '{self.path_with_protocol}'")
+            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
 
     def unlink(self, missing_ok: bool = False) -> None:
         """
@@ -725,19 +727,18 @@ class WebdavPath(URIPath):
 
         :param missing_ok: if False and target file not exists, raise FileNotFoundError
         """
-        try:
-            stat = self.stat()
-        except FileNotFoundError:
+        stat = self._stat_or_none()
+        if stat is None:
             if missing_ok:
                 return
-            raise
-        if stat.isdir:
+            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+        if stat.is_dir():
             raise IsADirectoryError(f"Is a directory: '{self.path_with_protocol}'")
         try:
             self._client.clean(self._remote_path)
         except RemoteResourceNotFound:
             if not missing_ok:
-                raise FileNotFoundError(f"No such file: '{self.path_with_protocol}'")
+                raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
 
     def walk(
         self, followlinks: bool = False
@@ -748,9 +749,8 @@ class WebdavPath(URIPath):
         :param followlinks: Ignored for WebDAV
         :returns: A 3-tuple generator (root, dirs, files)
         """
-        if not self.exists():
-            return
-        if self.is_file():
+        stat = self._stat_or_none()
+        if stat is None or stat.is_file():
             return
 
         stack = [self._remote_path]
@@ -847,14 +847,11 @@ class WebdavPath(URIPath):
         :param errors: error handling for text mode
         :returns: File-Like object
         """
-        try:
-            stat = self.stat()
-        except FileNotFoundError:
-            stat = None
+        stat = self._stat_or_none()
 
         if "x" in mode and stat is not None:
             raise FileExistsError("File exists: %r" % self.path_with_protocol)
-        if stat is not None and stat.isdir:
+        if stat is not None and stat.is_dir():
             raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
         if "w" in mode or "x" in mode or "a" in mode:
             self.parent.mkdir(parents=True, exist_ok=True)
@@ -931,14 +928,15 @@ class WebdavPath(URIPath):
         if str(dst_path).endswith("/"):
             raise IsADirectoryError("Is a directory: %r" % dst_path)
 
-        if self.is_dir():
+        dst_path = self.from_path(dst_path)
+        src_stat = self.stat()
+        if src_stat.is_dir():
             raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
-        if not overwrite and self.from_path(dst_path).exists():
+        if not overwrite and dst_path.exists():
             return
 
-        self.from_path(os.path.dirname(fspath(dst_path))).makedirs(exist_ok=True)
-        dst_path = self.from_path(dst_path)
+        dst_path.parent.makedirs(exist_ok=True)
 
         if self._is_same_backend(dst_path):
             if self._remote_path == dst_path._remote_path:
@@ -947,7 +945,7 @@ class WebdavPath(URIPath):
                 )
             self._client.copy(self._remote_path, dst_path._remote_path)
             if callback:
-                callback(self.stat().size)
+                callback(src_stat.size)
         else:
             with self.open("rb") as fsrc:
                 with dst_path.open("wb") as fdst:

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -25,6 +25,7 @@ class FakeWebdavClient:
 
     def __init__(self, options: dict = {}):
         self.options = options
+        self.info_calls = []
 
     def _relative_path(self, path: str) -> str:
         # XXX: pyfakefs not work in python3.14 when path is absolute
@@ -69,6 +70,7 @@ class FakeWebdavClient:
 
     def info(self, path: str) -> Dict:
         """Get file/directory info"""
+        self.info_calls.append(path)
         path = self._relative_path(path)
         if not os.path.exists(path):
             raise RemoteResourceNotFound(path)
@@ -465,6 +467,34 @@ def test_webdav_scan(webdav_mocker):
         list(webdav.webdav_scan_stat("webdav://host/B", missing_ok=False))
 
 
+def test_webdav_scan_stat_file_reuses_stat(webdav_mocker):
+    webdav.webdav_makedirs("webdav://host/A")
+    with webdav.webdav_open("webdav://host/A/1.json", "w") as f:
+        f.write("1.json")
+
+    path = webdav.WebdavPath("webdav://host/A/1.json")
+    client = path._client
+    client.info_calls.clear()
+
+    entries = list(path.scan_stat())
+
+    assert [entry.path for entry in entries] == ["webdav://host/A/1.json"]
+    assert client.info_calls == ["/A/1.json"]
+
+
+def test_webdav_scandir_reuses_stat(webdav_mocker):
+    webdav.webdav_makedirs("webdav://host/A")
+
+    path = webdav.WebdavPath("webdav://host/A")
+    client = path._client
+    client.info_calls.clear()
+
+    with path.scandir() as entries:
+        assert list(entries) == []
+
+    assert client.info_calls == ["/A"]
+
+
 def test_webdav_unlink(webdav_mocker):
     webdav.webdav_makedirs("webdav://host/A")
     with webdav.webdav_open("webdav://host/A/test", "w") as f:
@@ -557,11 +587,15 @@ def test_webdav_copy(webdav_mocker):
     def callback(length):
         assert length == len("1.json")
 
-    webdav.webdav_copy(
-        "webdav://host/A/1.json",
+    path = webdav.WebdavPath("webdav://host/A/1.json")
+    client = path._client
+    client.info_calls.clear()
+
+    path.copy(
         "webdav://host/A2/1.json.bak",
         callback=callback,
     )
+    assert client.info_calls.count("/A/1.json") == 1
 
     assert (
         webdav.webdav_stat("webdav://host/A/1.json").size


### PR DESCRIPTION
## Summary
- add a protected `BasePath._stat_or_none()` helper for internal three-state checks without changing public `stat()` semantics
- reuse the initial WebDAV stat in `scan_stat`, `scandir`, `walk`, `unlink`, and `open` instead of repeating try/stat blocks
- reuse source stat in `copy()` for directory guard and progress callback size
- use `StatResult.is_dir()` / `is_file()` consistently in WebDAV code touched by this flow
- keep WebDAV `FileNotFoundError` messages on `%r` formatting
- add WebDAV fake-client `info_calls` assertions to lock request-count behavior for file scan, scandir, and copy callback paths

## Tests
- `make style_check`
- `make static_check`
- `pytest tests/test_webdav.py::test_webdav_scan_stat_file_reuses_stat tests/test_webdav.py::test_webdav_scandir_reuses_stat tests/test_webdav.py::test_webdav_copy tests/test_webdav.py::test_webdav_unlink tests/test_webdav.py::test_webdav_open tests/test_webdav_path.py::test_unlink_missing_ok_false tests/test_webdav_path.py::test_remove_missing_ok_false -q`
- `pytest tests/test_webdav.py tests/test_webdav_path.py tests/lib/test_webdav_memory_handler.py tests/lib/test_webdav_prefetch_reader.py -q` (local env still fails existing `test_provide_connect_info` because machine WebDAV credentials are loaded; the rest passed: 137 passed)