### PR TITLE
feat: add recursive rename flag

### DIFF
--- a/megfile/cli.py
+++ b/megfile/cli.py
@@ -386,7 +386,9 @@ def mv(
         if recursive:
             if src_protocol == dst_protocol:
                 with tqdm(total=1) as t:
-                    SmartPath(src_path).rename(dst_path, overwrite=not skip)
+                    SmartPath(src_path).rename(
+                        dst_path, overwrite=not skip, recursive=True
+                    )
                     t.update(1)
             else:
                 smart_sync_with_progress(
@@ -396,7 +398,9 @@ def mv(
         else:
             if src_protocol == dst_protocol:
                 with tqdm(total=1) as t:
-                    SmartPath(src_path).rename(dst_path, overwrite=not skip)
+                    SmartPath(src_path).rename(
+                        dst_path, overwrite=not skip, recursive=False
+                    )
                     t.update(1)
             else:
                 file_size = smart_stat(src_path).size

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -491,12 +491,15 @@ class FSPath(URIPath):
             )
         )
 
-    def rename(self, dst_path: PathLike, overwrite: bool = True) -> "FSPath":
+    def rename(
+        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
+    ) -> "FSPath":
         """
         rename file on fs
 
         :param dst_path: Given destination path
         :param overwrite: whether or not overwrite file when exists
+        :param recursive: whether or not rename directory recursively
         """
         self._check_int_path()
 
@@ -506,8 +509,12 @@ class FSPath(URIPath):
             if os.path.exists(src_path):
                 os.remove(src_path)
             return self.from_path(dst_path)
-        else:
-            os.makedirs(dst_path, exist_ok=True)
+        if not os.path.exists(src_path):
+            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+        if not recursive and os.path.isdir(src_path):
+            raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
+
+        os.makedirs(dst_path, exist_ok=True)
 
         with os.scandir(src_path) as entries:
             for file_entry in entries:
@@ -518,7 +525,9 @@ class FSPath(URIPath):
                     dst_file_path = os.path.join(dst_file_path, relative_path)
                 if os.path.exists(dst_file_path) and file_entry.is_dir():
                     self.from_path(src_file_path).rename(
-                        dst_file_path, overwrite=overwrite
+                        dst_file_path,
+                        overwrite=overwrite,
+                        recursive=recursive,
                     )
                 else:
                     _fs_rename_file(src_file_path, dst_file_path, overwrite=overwrite)

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -375,19 +375,26 @@ class HdfsPath(URIPath):
         with raise_hdfs_error(self.path_with_protocol):
             self._client.makedirs(self.path_without_protocol, permission=mode)
 
-    def rename(self, dst_path: PathLike, overwrite: bool = True) -> "HdfsPath":
+    def rename(
+        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
+    ) -> "HdfsPath":
         """
         Move hdfs file path from src_path to dst_path
 
         :param dst_path: Given destination path
         :param overwrite: whether or not overwrite file when exists
+        :param recursive: whether or not rename directory recursively
         """
         dst_path = self.from_path(dst_path)
-        if self.is_dir():
+        src_stat = self.stat()
+        if src_stat.is_dir():
+            if not recursive:
+                raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
             for filename in self.iterdir():
                 filename.rename(
                     dst_path.joinpath(filename.relative_to(self.path_with_protocol)),
                     overwrite=overwrite,
+                    recursive=recursive,
                 )
         else:
             if overwrite:
@@ -406,7 +413,7 @@ class HdfsPath(URIPath):
 
         :param dst_path: Given destination path
         """
-        self.rename(dst_path=dst_path, overwrite=overwrite)
+        self.rename(dst_path=dst_path, overwrite=overwrite, recursive=True)
 
     def remove(self, missing_ok: bool = False) -> None:
         """

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -726,12 +726,18 @@ class BasePath:
         """
         return self.chmod(mode=mode, follow_symlinks=False)
 
-    def rename(self: Self, dst_path: "PathLike", overwrite: bool = True) -> Self:
+    def rename(
+        self: Self,
+        dst_path: "PathLike",
+        overwrite: bool = True,
+        recursive: bool = True,
+    ) -> Self:
         """
         rename file
 
         :param dst_path: Given destination path
         :param overwrite: whether or not overwrite file when exists
+        :param recursive: whether or not rename directory recursively
         """
         raise NotImplementedError(f"'rename' is unsupported on '{type(self)}'")
 

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -2079,7 +2079,9 @@ class S3Path(URIPath):
         for src_file_path, dst_file_path in _s3_scan_pairs(
             self.path_with_protocol, dst_url
         ):
-            S3Path(src_file_path).rename(dst_file_path, overwrite=overwrite)
+            S3Path(src_file_path).rename(
+                dst_file_path, overwrite=overwrite, recursive=False
+            )
 
     def remove(self, missing_ok: bool = False) -> None:
         """
@@ -2166,13 +2168,21 @@ class S3Path(URIPath):
                     "No such file or directory: %r" % self.path_with_protocol
                 )
 
-    def rename(self, dst_path: PathLike, overwrite: bool = True) -> "S3Path":
+    def rename(
+        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
+    ) -> "S3Path":
         """
         Move s3 file path from src_url to dst_url
 
         :param dst_path: Given destination path
         :param overwrite: whether or not overwrite file when exists
+        :param recursive: whether or not rename directory recursively
         """
+        if not recursive:
+            self.copy(dst_path, overwrite=overwrite)
+            self.unlink()
+            return self.from_path(dst_path)
+
         if self.is_file():
             self.copy(dst_path, overwrite=overwrite)
         else:

--- a/megfile/sftp2_path.py
+++ b/megfile/sftp2_path.py
@@ -636,13 +636,17 @@ class Sftp2Path(URIPath):
     def _is_same_protocol(self, path):
         return is_sftp2(path)
 
-    def rename(self, dst_path: PathLike, overwrite: bool = True) -> "Sftp2Path":
+    def rename(
+        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
+    ) -> "Sftp2Path":
         """Rename file on sftp2"""
         if not self._is_same_protocol(dst_path):
             raise OSError(f"Not a {self.protocol} path: {dst_path!r}")
 
         dst_path = self.from_path(str(dst_path).rstrip("/"))
         src_stat = self.stat()
+        if src_stat.is_dir() and not recursive:
+            raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if self._is_same_backend(dst_path):
             if overwrite:
@@ -652,10 +656,12 @@ class Sftp2Path(URIPath):
                 self.sync(dst_path, overwrite=overwrite)
                 self.remove(missing_ok=True)
         else:
-            if self.is_dir():
+            if src_stat.is_dir():
                 for file_entry in self.scandir():
                     self.from_path(file_entry.path).rename(
-                        dst_path.joinpath(file_entry.name)
+                        dst_path.joinpath(file_entry.name),
+                        overwrite=overwrite,
+                        recursive=recursive,
                     )
                 self._client.rmdir(self._remote_path)
             else:

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -921,12 +921,15 @@ class SftpPath(URIPath):
     def _is_same_protocol(self, path):
         return is_sftp(path)
 
-    def rename(self, dst_path: PathLike, overwrite: bool = True) -> "SftpPath":
+    def rename(
+        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
+    ) -> "SftpPath":
         """
         rename file on sftp
 
         :param dst_path: Given destination path
         :param overwrite: whether or not overwrite file when exists
+        :param recursive: whether or not rename directory recursively
         """
         if not self._is_same_protocol(dst_path):
             raise OSError("Not a %s path: %r" % (self.protocol, dst_path))
@@ -934,6 +937,8 @@ class SftpPath(URIPath):
         dst_path = self.from_path(str(dst_path).rstrip("/"))
 
         src_stat = self.stat()
+        if src_stat.is_dir() and not recursive:
+            raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if self._is_same_backend(dst_path):
             if overwrite:
@@ -943,10 +948,12 @@ class SftpPath(URIPath):
                 self.sync(dst_path, overwrite=overwrite)
                 self.remove(missing_ok=True)
         else:
-            if self.is_dir():
+            if src_stat.is_dir():
                 for file_entry in self.scandir():
                     self.from_path(file_entry.path).rename(
-                        dst_path.joinpath(file_entry.name)
+                        dst_path.joinpath(file_entry.name),
+                        overwrite=overwrite,
+                        recursive=recursive,
                     )
                 self._client.rmdir(self._real_path)
             else:

--- a/megfile/smart.py
+++ b/megfile/smart.py
@@ -635,13 +635,13 @@ def smart_rename(
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    if smart_isdir(src_path):
-        raise IsADirectoryError("%r is a directory" % src_path)
     src_protocol = SmartPath._extract_protocol(src_path)
     dst_protocol = SmartPath._extract_protocol(dst_path)
     if src_protocol == dst_protocol:
-        SmartPath(src_path).rename(dst_path, overwrite=overwrite)
+        SmartPath(src_path).rename(dst_path, overwrite=overwrite, recursive=False)
         return
+    if smart_isdir(src_path):
+        raise IsADirectoryError("%r is a directory" % src_path)
     smart_copy(src_path, dst_path, overwrite=overwrite)
     smart_unlink(src_path)
 
@@ -657,7 +657,7 @@ def smart_move(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) -
     src_protocol = SmartPath._extract_protocol(src_path)
     dst_protocol = SmartPath._extract_protocol(dst_path)
     if src_protocol == dst_protocol:
-        SmartPath(src_path).rename(dst_path, overwrite=overwrite)
+        SmartPath(src_path).rename(dst_path, overwrite=overwrite, recursive=True)
         return
     smart_sync(src_path, dst_path, followlinks=True, overwrite=overwrite)
     smart_remove(src_path)

--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -584,17 +584,23 @@ class WebdavPath(URIPath):
         """Check if path is a WebDAV path"""
         return is_webdav(path)
 
-    def rename(self, dst_path: PathLike, overwrite: bool = True) -> "WebdavPath":
+    def rename(
+        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
+    ) -> "WebdavPath":
         """
         Rename file on WebDAV
 
         :param dst_path: Given destination path
         :param overwrite: whether or not overwrite file when exists
+        :param recursive: whether or not rename directory recursively
         """
         if not self._is_same_protocol(dst_path):
             raise OSError("Not a %s path: %r" % (self.protocol, dst_path))
 
         dst_path = self.from_path(str(dst_path).rstrip("/"))
+        src_stat = self.stat()
+        if src_stat.is_dir() and not recursive:
+            raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if self._is_same_backend(dst_path):
             if overwrite:
@@ -603,10 +609,12 @@ class WebdavPath(URIPath):
                 self._remote_path, dst_path._remote_path, overwrite=overwrite
             )
         else:
-            if self.is_dir():
+            if src_stat.is_dir():
                 for file_entry in self.scandir():
                     self.from_path(file_entry.path).rename(
-                        dst_path.joinpath(file_entry.name), overwrite=overwrite
+                        dst_path.joinpath(file_entry.name),
+                        overwrite=overwrite,
+                        recursive=recursive,
                     )
                 self.rmdir()
             else:

--- a/tests/compat/fs.py
+++ b/tests/compat/fs.py
@@ -561,15 +561,21 @@ def fs_lstat(path: PathLike) -> StatResult:
     return FSPath(path).lstat()
 
 
-def fs_rename(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) -> None:
+def fs_rename(
+    src_path: PathLike,
+    dst_path: PathLike,
+    overwrite: bool = True,
+    recursive: bool = True,
+) -> None:
     """
     rename file on fs
 
     :param src_path: Given path
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
+    :param recursive: whether or not rename directory recursively
     """
-    FSPath(src_path).rename(dst_path, overwrite=overwrite)
+    FSPath(src_path).rename(dst_path, overwrite=overwrite, recursive=recursive)
 
 
 def fs_move(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) -> None:

--- a/tests/compat/s3.py
+++ b/tests/compat/s3.py
@@ -417,14 +417,17 @@ def s3_readlink(path) -> str:
     return S3Path(path).readlink().path_with_protocol
 
 
-def s3_rename(src_url: PathLike, dst_url: PathLike, overwrite: bool = True) -> None:
+def s3_rename(
+    src_url: PathLike, dst_url: PathLike, overwrite: bool = True, recursive: bool = True
+) -> None:
     """
     Move s3 file path from src_url to dst_url
 
     :param dst_url: Given destination path
     :param overwrite: whether or not overwrite file when exists
+    :param recursive: whether or not rename directory recursively
     """
-    S3Path(src_url).rename(dst_url, overwrite=overwrite)
+    S3Path(src_url).rename(dst_url, overwrite=overwrite, recursive=recursive)
 
 
 def s3_glob(

--- a/tests/compat/sftp.py
+++ b/tests/compat/sftp.py
@@ -341,7 +341,10 @@ def sftp_realpath(path: PathLike) -> str:
 
 
 def sftp_rename(
-    src_path: PathLike, dst_path: PathLike, overwrite: bool = True
+    src_path: PathLike,
+    dst_path: PathLike,
+    overwrite: bool = True,
+    recursive: bool = True,
 ) -> "SftpPath":
     """
     rename file on sftp
@@ -349,8 +352,9 @@ def sftp_rename(
     :param src_path: Given path
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
+    :param recursive: whether or not rename directory recursively
     """
-    return SftpPath(src_path).rename(dst_path, overwrite=overwrite)
+    return SftpPath(src_path).rename(dst_path, overwrite=overwrite, recursive=recursive)
 
 
 def sftp_move(

--- a/tests/compat/sftp2.py
+++ b/tests/compat/sftp2.py
@@ -492,7 +492,10 @@ def sftp2_realpath(path: PathLike) -> str:
 
 
 def sftp2_rename(
-    src_path: PathLike, dst_path: PathLike, overwrite: bool = True
+    src_path: PathLike,
+    dst_path: PathLike,
+    overwrite: bool = True,
+    recursive: bool = True,
 ) -> "Sftp2Path":
     """
     rename file on sftp2
@@ -500,8 +503,11 @@ def sftp2_rename(
     :param src_path: Given path
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
+    :param recursive: whether or not rename directory recursively
     """
-    return Sftp2Path(src_path).rename(dst_path, overwrite=overwrite)
+    return Sftp2Path(src_path).rename(
+        dst_path, overwrite=overwrite, recursive=recursive
+    )
 
 
 def sftp2_move(

--- a/tests/compat/webdav.py
+++ b/tests/compat/webdav.py
@@ -337,7 +337,10 @@ def webdav_realpath(path: PathLike) -> str:
 
 
 def webdav_rename(
-    src_path: PathLike, dst_path: PathLike, overwrite: bool = True
+    src_path: PathLike,
+    dst_path: PathLike,
+    overwrite: bool = True,
+    recursive: bool = True,
 ) -> "WebdavPath":
     """
     Rename file on WebDAV
@@ -345,8 +348,11 @@ def webdav_rename(
     :param src_path: Given path
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
+    :param recursive: whether or not rename directory recursively
     """
-    return WebdavPath(src_path).rename(dst_path, overwrite=overwrite)
+    return WebdavPath(src_path).rename(
+        dst_path, overwrite=overwrite, recursive=recursive
+    )
 
 
 def webdav_move(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -40,6 +40,7 @@ from megfile.interfaces import Access, FileEntry, StatResult
 from megfile.s3_path import (
     S3CachedHandler,
     S3MemoryHandler,
+    S3Path,
     _group_s3path_by_bucket,
     _group_s3path_by_prefix,
     _parse_s3_url_ignore_brace,
@@ -1267,6 +1268,43 @@ def test_s3_rename(truncating_client):
     with s3.s3_open("s3://bucketA/folderAA/folderAAA/fileAAAA1", "r") as f:
         assert f.read() == "fileAAAA2"
     assert s3.s3_exists("s3://bucketA/folderAA/folderAAA/fileAAAA2") is False
+
+
+def test_s3_rename_recursive_false_does_not_stat(mocker, s3_empty_client):
+    s3_empty_client.create_bucket(Bucket="bucket")
+    s3_empty_client.put_object(Bucket="bucket", Key="src", Body=b"value")
+    stat = mocker.patch.object(S3Path, "stat")
+
+    s3.s3_rename("s3://bucket/src", "s3://bucket/dst", recursive=False)
+
+    stat.assert_not_called()
+    assert s3.s3_exists("s3://bucket/src") is False
+    assert (
+        s3_empty_client.get_object(Bucket="bucket", Key="dst")["Body"].read()
+        == b"value"
+    )
+
+
+def test_s3_rename_recursive_true_does_not_copy_directory_root(mocker, s3_empty_client):
+    s3_empty_client.create_bucket(Bucket="bucket")
+    s3_empty_client.put_object(Bucket="bucket", Key="src/a", Body=b"a")
+    s3_empty_client.put_object(Bucket="bucket", Key="src/b", Body=b"b")
+    copy_calls = []
+    original_copy = S3Path.copy
+
+    def copy_spy(self, *args, **kwargs):
+        copy_calls.append(self.path_with_protocol)
+        return original_copy(self, *args, **kwargs)
+
+    mocker.patch.object(S3Path, "copy", copy_spy)
+
+    s3.s3_rename("s3://bucket/src", "s3://bucket/dst", recursive=True)
+
+    assert copy_calls == ["s3://bucket/src/a", "s3://bucket/src/b"]
+    assert s3.s3_exists("s3://bucket/src/a") is False
+    assert s3.s3_exists("s3://bucket/src/b") is False
+    assert s3.s3_exists("s3://bucket/dst/a")
+    assert s3.s3_exists("s3://bucket/dst/b")
 
 
 def test_s3_unlink(s3_setup):

--- a/tests/test_smart.py
+++ b/tests/test_smart.py
@@ -495,7 +495,7 @@ def test_smart_move(mocker):
     funcA.return_value = None
     res = smart.smart_move("s3://bucket/a", "s3://bucket/b")
     assert res is None
-    funcA.assert_called_once_with("s3://bucket/b", overwrite=True)
+    funcA.assert_called_once_with("s3://bucket/b", overwrite=True, recursive=True)
 
     res = smart.smart_move("/bucket/a", "/bucket/b")
     assert res is None
@@ -511,11 +511,13 @@ def test_smart_move(mocker):
 
 
 @patch.object(SmartPath, "rename")
-def test_smart_rename(funcA):
+def test_smart_rename(funcA, mocker):
+    smart_isdir = mocker.patch("megfile.smart.smart_isdir")
     funcA.return_value = None
-    res = smart.smart_move("s3://bucket/a", "s3://bucket/b")
+    res = smart.smart_rename("s3://bucket/a", "s3://bucket/b")
     assert res is None
-    funcA.assert_called_once_with("s3://bucket/b", overwrite=True)
+    funcA.assert_called_once_with("s3://bucket/b", overwrite=True, recursive=False)
+    smart_isdir.assert_not_called()
 
 
 def test_smart_rename_fs(s3_empty_client, filesystem):

--- a/tests/test_webdav_path.py
+++ b/tests/test_webdav_path.py
@@ -594,6 +594,24 @@ def test_rename_directory(webdav_mocker):
     assert WebdavPath("webdav://host/B/file.txt").exists()
 
 
+def test_rename_directory_recursive_false_raises(webdav_mocker):
+    """Test rename(recursive=False) treats source as a single file."""
+    webdav.webdav_makedirs("webdav://host/A")
+    with webdav.webdav_open("webdav://host/A/file.txt", "w") as f:
+        f.write("test")
+
+    path = WebdavPath("webdav://host/A")
+    client = path._client
+    client.info_calls.clear()
+
+    with pytest.raises(IsADirectoryError):
+        path.rename("webdav://host/B", recursive=False)
+
+    assert client.info_calls == ["/A"]
+    assert WebdavPath("webdav://host/A/file.txt").exists()
+    assert not WebdavPath("webdav://host/B").exists()
+
+
 def test_generate_path_object(webdav_mocker):
     """Test _generate_path_object method"""
     path = WebdavPath("webdav://host/A/B/C")


### PR DESCRIPTION
## Summary
- add `recursive` to `Path.rename()` implementations, defaulting to existing file-or-directory behavior
- make `smart_rename()` call `rename(..., overwrite=overwrite, recursive=False)` and `smart_move()` call `rename(..., overwrite=overwrite, recursive=True)` for same-protocol paths
- keep `recursive=False` as file-only semantics; S3 uses the file copy/delete path without a pre-stat
- keep S3 `recursive=True` on the old `is_file() -> copy else sync/remove` path so directory rename does not add a failed root copy/stat before recursive sync
- update CLI progress rename paths and test compat wrappers to pass the intended recursive mode with keyword bool flags

## Tests
- `make style_check`
- `make static_check`
- `pytest tests/test_smart.py::test_smart_move tests/test_smart.py::test_smart_rename tests/test_smart.py::test_smart_rename_fs tests/test_s3.py::test_s3_rename tests/test_s3.py::test_s3_rename_recursive_false_does_not_stat tests/test_s3.py::test_s3_rename_recursive_true_does_not_copy_directory_root tests/test_webdav_path.py::test_rename_same_backend tests/test_webdav_path.py::test_rename_directory tests/test_webdav_path.py::test_rename_directory_recursive_false_raises -q`

Note: running the full `tests/test_webdav_path.py` file on this devbox hits preconfigured WebDAV credentials from the local megfile config in `test_provide_connect_info`; the rename-specific WebDAV tests above pass.