### PR TITLE
style: use keyword arguments for bool flags

### DIFF
--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -91,7 +91,9 @@ def fs_copy(
     :param followlinks: False if regard symlink as file, else True
     :param overwrite: whether or not overwrite file when exists, default is True
     """
-    return FSPath(src_path).copy(dst_path, callback, followlinks, overwrite)
+    return FSPath(src_path).copy(
+        dst_path, callback, followlinks=followlinks, overwrite=overwrite
+    )
 
 
 def _fs_rename_file(
@@ -371,8 +373,8 @@ class FSPath(URIPath):
 
         for path in _create_missing_ok_generator(
             iglob(fspath(glob_path), recursive=recursive),
-            missing_ok,
-            FileNotFoundError("No match any file: %r" % glob_path),
+            missing_ok=missing_ok,
+            error=FileNotFoundError("No match any file: %r" % glob_path),
         ):
             yield self.from_path(path)
 
@@ -500,7 +502,7 @@ class FSPath(URIPath):
 
         src_path, dst_path = fspath(self.path_without_protocol), fspath(dst_path)
         if os.path.isfile(src_path):
-            _fs_rename_file(src_path, dst_path, overwrite)
+            _fs_rename_file(src_path, dst_path, overwrite=overwrite)
             if os.path.exists(src_path):
                 os.remove(src_path)
             return self.from_path(dst_path)
@@ -515,9 +517,11 @@ class FSPath(URIPath):
                 if relative_path and relative_path != ".":
                     dst_file_path = os.path.join(dst_file_path, relative_path)
                 if os.path.exists(dst_file_path) and file_entry.is_dir():
-                    self.from_path(src_file_path).rename(dst_file_path, overwrite)
+                    self.from_path(src_file_path).rename(
+                        dst_file_path, overwrite=overwrite
+                    )
                 else:
-                    _fs_rename_file(src_file_path, dst_file_path, overwrite)
+                    _fs_rename_file(src_file_path, dst_file_path, overwrite=overwrite)
 
             shutil.rmtree(src_path, ignore_errors=True)
 
@@ -574,8 +578,8 @@ class FSPath(URIPath):
         """
         return _create_missing_ok_generator(
             self._scan(followlinks=followlinks),
-            missing_ok,
-            FileNotFoundError("No match any file in: %r" % self.path),
+            missing_ok=missing_ok,
+            error=FileNotFoundError("No match any file in: %r" % self.path),
         )
 
     def scan_stat(

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -286,8 +286,8 @@ class HdfsPath(URIPath):
         fs_func = FSFunc(_exist, _is_dir, _scandir)
         for real_path in _create_missing_ok_generator(
             iglob(fspath(glob_path), recursive=recursive, fs=fs_func),
-            missing_ok,
-            FileNotFoundError("No match any file: %r" % glob_path),
+            missing_ok=missing_ok,
+            error=FileNotFoundError("No match any file: %r" % glob_path),
         ):
             yield self.from_path(real_path)
 

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -1364,7 +1364,9 @@ def s3_copy(
     :param followlinks: False if regard symlink as file, else True
     :param overwrite: whether or not overwrite file when exists, default is True
     """
-    return S3Path(src_url).copy(dst_url, callback, followlinks, overwrite)
+    return S3Path(src_url).copy(
+        dst_url, callback, followlinks=followlinks, overwrite=overwrite
+    )
 
 
 def s3_download(
@@ -1766,7 +1768,7 @@ class S3Path(URIPath):
         if not bucket:  # s3:// => True, s3:///key => False
             return not key
 
-        return self.is_file(followlinks) or self.is_dir()
+        return self.is_file(followlinks=followlinks) or self.is_dir()
 
     def getmtime(self, follow_symlinks: bool = False) -> float:
         """
@@ -1861,15 +1863,15 @@ class S3Path(URIPath):
                 for group_s3_pathname_2 in _group_s3path_by_prefix(group_s3_pathname_1):
                     for file_entry in _s3_glob_stat_single_path(
                         group_s3_pathname_2,
-                        recursive,
-                        missing_ok,
+                        recursive=recursive,
+                        missing_ok=missing_ok,
                     ):
                         yield file_entry
 
         return _create_missing_ok_generator(
             create_generator(),
-            missing_ok,
-            S3FileNotFoundError("No match any file: %r" % s3_pathname),
+            missing_ok=missing_ok,
+            error=S3FileNotFoundError("No match any file: %r" % s3_pathname),
         )
 
     def iglob(
@@ -2077,7 +2079,7 @@ class S3Path(URIPath):
         for src_file_path, dst_file_path in _s3_scan_pairs(
             self.path_with_protocol, dst_url
         ):
-            S3Path(src_file_path).rename(dst_file_path, overwrite)
+            S3Path(src_file_path).rename(dst_file_path, overwrite=overwrite)
 
     def remove(self, missing_ok: bool = False) -> None:
         """
@@ -2265,8 +2267,10 @@ class S3Path(URIPath):
 
         return _create_missing_ok_generator(
             create_generator(),
-            missing_ok,
-            S3FileNotFoundError("No match any file in: %r" % self.path_with_protocol),
+            missing_ok=missing_ok,
+            error=S3FileNotFoundError(
+                "No match any file in: %r" % self.path_with_protocol
+            ),
         )
 
     def scandir(self) -> ContextIterator:

--- a/megfile/sftp2_path.py
+++ b/megfile/sftp2_path.py
@@ -559,8 +559,8 @@ class Sftp2Path(URIPath):
         fs = FSFunc(_exist, _is_dir, _scandir)
         for remote_path in _create_missing_ok_generator(
             iglob(fspath(glob_path), recursive=recursive, fs=fs),
-            missing_ok,
-            FileNotFoundError(f"No match any file: {glob_path!r}"),
+            missing_ok=missing_ok,
+            error=FileNotFoundError(f"No match any file: {glob_path!r}"),
         ):
             yield self.from_path(remote_path)
 
@@ -723,8 +723,10 @@ class Sftp2Path(URIPath):
 
         return _create_missing_ok_generator(
             create_generator(),
-            missing_ok,
-            FileNotFoundError(f"No match any file in: {self.path_with_protocol!r}"),
+            missing_ok=missing_ok,
+            error=FileNotFoundError(
+                f"No match any file in: {self.path_with_protocol!r}"
+            ),
         )
 
     def scandir(self) -> ContextIterator:

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -452,7 +452,9 @@ def sftp_copy(
     :raises IsADirectoryError: If the source is a directory.
     :raises OSError: If there is an error copying the file.
     """
-    return SftpPath(src_path).copy(dst_path, callback, followlinks, overwrite)
+    return SftpPath(src_path).copy(
+        dst_path, callback, followlinks=followlinks, overwrite=overwrite
+    )
 
 
 def sftp_download(
@@ -788,8 +790,8 @@ class SftpPath(URIPath):
         fs = FSFunc(_exist, _is_dir, _scandir)
         for real_path in _create_missing_ok_generator(
             iglob(fspath(glob_path), recursive=recursive, fs=fs),
-            missing_ok,
-            FileNotFoundError("No match any file: %r" % glob_path),
+            missing_ok=missing_ok,
+            error=FileNotFoundError("No match any file: %r" % glob_path),
         ):
             yield self.from_path(real_path)
 
@@ -1041,8 +1043,10 @@ class SftpPath(URIPath):
 
         return _create_missing_ok_generator(
             create_generator(),
-            missing_ok,
-            FileNotFoundError("No match any file in: %r" % self.path_with_protocol),
+            missing_ok=missing_ok,
+            error=FileNotFoundError(
+                "No match any file in: %r" % self.path_with_protocol
+            ),
         )
 
     def scandir(self) -> ContextIterator:

--- a/megfile/smart.py
+++ b/megfile/smart.py
@@ -683,7 +683,7 @@ def smart_makedirs(path: PathLike, exist_ok: bool = False) -> None:
     :param missing_ok: if False and target directory not exists, raise FileNotFoundError
     :raises: PermissionError, FileExistsError
     """
-    SmartPath(path).makedirs(exist_ok)
+    SmartPath(path).makedirs(exist_ok=exist_ok)
 
 
 def smart_open(

--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -457,8 +457,8 @@ class WebdavPath(URIPath):
 
         return _create_missing_ok_generator(
             create_generator(),
-            missing_ok,
-            FileNotFoundError("No match any file: %r" % glob_path),
+            missing_ok=missing_ok,
+            error=FileNotFoundError("No match any file: %r" % glob_path),
         )
 
     def iglob(
@@ -685,8 +685,10 @@ class WebdavPath(URIPath):
 
         return _create_missing_ok_generator(
             create_generator(),
-            missing_ok,
-            FileNotFoundError("No match any file in: %r" % self.path_with_protocol),
+            missing_ok=missing_ok,
+            error=FileNotFoundError(
+                "No match any file in: %r" % self.path_with_protocol
+            ),
         )
 
     def scandir(self) -> ContextIterator:

--- a/tests/compat/fs.py
+++ b/tests/compat/fs.py
@@ -100,7 +100,7 @@ def fs_exists(path: PathLike, followlinks: bool = False) -> bool:
     :returns: True if the path exists, else False
 
     """
-    return FSPath(path).exists(followlinks)
+    return FSPath(path).exists(followlinks=followlinks)
 
 
 def fs_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
@@ -112,7 +112,7 @@ def fs_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
     :param path: Given path
     :returns: last-modified time
     """
-    return FSPath(path).getmtime(follow_symlinks)
+    return FSPath(path).getmtime(follow_symlinks=follow_symlinks)
 
 
 def fs_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
@@ -127,7 +127,7 @@ def fs_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
     :returns: File size
 
     """
-    return FSPath(path).getsize(follow_symlinks)
+    return FSPath(path).getsize(follow_symlinks=follow_symlinks)
 
 
 def fs_expanduser(path: PathLike):
@@ -151,7 +151,7 @@ def fs_isdir(path: PathLike, followlinks: bool = False) -> bool:
     :returns: True if the path is a directory, else False
 
     """
-    return FSPath(path).is_dir(followlinks)
+    return FSPath(path).is_dir(followlinks=followlinks)
 
 
 def fs_isfile(path: PathLike, followlinks: bool = False) -> bool:
@@ -168,7 +168,7 @@ def fs_isfile(path: PathLike, followlinks: bool = False) -> bool:
     :returns: True if the path is a file, else False
 
     """
-    return FSPath(path).is_file(followlinks)
+    return FSPath(path).is_file(followlinks=followlinks)
 
 
 def fs_listdir(path: Optional[PathLike] = None) -> List[str]:
@@ -222,7 +222,7 @@ def fs_remove(path: PathLike, missing_ok: bool = False) -> None:
     :param missing_ok: if False and target file/directory not exists,
         raise FileNotFoundError
     """
-    return FSPath(path).remove(missing_ok)
+    return FSPath(path).remove(missing_ok=missing_ok)
 
 
 def fs_scan(
@@ -241,7 +241,7 @@ def fs_scan(
         raise FileNotFoundError
     :returns: A file path generator
     """
-    return FSPath(path).scan(missing_ok, followlinks)
+    return FSPath(path).scan(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def fs_scan_stat(
@@ -256,7 +256,7 @@ def fs_scan_stat(
         raise FileNotFoundError
     :returns: A file path generator
     """
-    return FSPath(path).scan_stat(missing_ok, followlinks)
+    return FSPath(path).scan_stat(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def fs_scandir(path: Optional[PathLike] = None) -> Iterator[FileEntry]:
@@ -298,7 +298,7 @@ def fs_stat(path: PathLike, follow_symlinks=True) -> StatResult:
     :param path: Given path
     :returns: StatResult
     """
-    return FSPath(path).stat(follow_symlinks)
+    return FSPath(path).stat(follow_symlinks=follow_symlinks)
 
 
 def fs_unlink(path: PathLike, missing_ok: bool = False) -> None:
@@ -308,7 +308,7 @@ def fs_unlink(path: PathLike, missing_ok: bool = False) -> None:
     :param path: Given path
     :param missing_ok: if False and target file not exists, raise FileNotFoundError
     """
-    return FSPath(path).unlink(missing_ok)
+    return FSPath(path).unlink(missing_ok=missing_ok)
 
 
 def fs_walk(
@@ -339,7 +339,7 @@ def fs_walk(
 
     :returns: A 3-tuple generator
     """
-    return FSPath(path).walk(followlinks)
+    return FSPath(path).walk(followlinks=followlinks)
 
 
 def fs_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = False):
@@ -352,7 +352,7 @@ def fs_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = Fal
 
     returns: md5 of file
     """
-    return FSPath(path).md5(recalculate, followlinks)
+    return FSPath(path).md5(recalculate=recalculate, followlinks=followlinks)
 
 
 def fs_sync(
@@ -371,7 +371,9 @@ def fs_sync(
         priority is higher than 'overwrite', default is False
     :param overwrite: whether or not overwrite file when exists, default is True
     """
-    return FSPath(src_path).sync(dst_path, followlinks, force, overwrite)
+    return FSPath(src_path).sync(
+        dst_path, followlinks=followlinks, force=force, overwrite=overwrite
+    )
 
 
 def fs_symlink(src_path: PathLike, dst_path: PathLike) -> None:
@@ -567,7 +569,7 @@ def fs_rename(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) ->
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    FSPath(src_path).rename(dst_path, overwrite)
+    FSPath(src_path).rename(dst_path, overwrite=overwrite)
 
 
 def fs_move(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) -> None:
@@ -578,7 +580,7 @@ def fs_move(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) -> N
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    return fs_rename(src_path, dst_path, overwrite)
+    return fs_rename(src_path, dst_path, overwrite=overwrite)
 
 
 def fs_open(path: PathLike, mode: str = "r", **kwargs) -> IO:

--- a/tests/compat/hdfs.py
+++ b/tests/compat/hdfs.py
@@ -43,7 +43,7 @@ def hdfs_exists(path: PathLike, followlinks: bool = False) -> bool:
     :param path: Given path
     :returns: True if path exists, else False
     """
-    return HdfsPath(path).exists(followlinks)
+    return HdfsPath(path).exists(followlinks=followlinks)
 
 
 def hdfs_stat(path: PathLike, follow_symlinks=True) -> StatResult:
@@ -61,7 +61,7 @@ def hdfs_stat(path: PathLike, follow_symlinks=True) -> StatResult:
     :returns: StatResult
     :raises: FileNotFoundError
     """
-    return HdfsPath(path).stat(follow_symlinks)
+    return HdfsPath(path).stat(follow_symlinks=follow_symlinks)
 
 
 def hdfs_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
@@ -78,7 +78,7 @@ def hdfs_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
     :returns: Last-modified time
     :raises: FileNotFoundError
     """
-    return HdfsPath(path).getmtime(follow_symlinks)
+    return HdfsPath(path).getmtime(follow_symlinks=follow_symlinks)
 
 
 def hdfs_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
@@ -97,7 +97,7 @@ def hdfs_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
     :returns: File size
     :raises: FileNotFoundError
     """
-    return HdfsPath(path).getsize(follow_symlinks)
+    return HdfsPath(path).getsize(follow_symlinks=follow_symlinks)
 
 
 def hdfs_isdir(path: PathLike, followlinks: bool = False) -> bool:
@@ -112,7 +112,7 @@ def hdfs_isdir(path: PathLike, followlinks: bool = False) -> bool:
         Because hdfs symlink not support dir.
     :returns: True if path is hdfs directory, else False
     """
-    return HdfsPath(path).is_dir(followlinks)
+    return HdfsPath(path).is_dir(followlinks=followlinks)
 
 
 def hdfs_isfile(path: PathLike, followlinks: bool = False) -> bool:
@@ -122,7 +122,7 @@ def hdfs_isfile(path: PathLike, followlinks: bool = False) -> bool:
     :param path: Given path
     :returns: True if path is hdfs file, else False
     """
-    return HdfsPath(path).is_file(followlinks)
+    return HdfsPath(path).is_file(followlinks=followlinks)
 
 
 def hdfs_listdir(path: PathLike) -> List[str]:
@@ -154,7 +154,7 @@ def hdfs_move(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) ->
     :param src_path: Given path
     :param dst_path: Given destination path
     """
-    return HdfsPath(src_path).move(dst_path, overwrite)
+    return HdfsPath(src_path).move(dst_path, overwrite=overwrite)
 
 
 def hdfs_remove(path: PathLike, missing_ok: bool = False) -> None:
@@ -167,7 +167,7 @@ def hdfs_remove(path: PathLike, missing_ok: bool = False) -> None:
         raise FileNotFoundError
     :raises: FileNotFoundError, UnsupportedError
     """
-    return HdfsPath(path).remove(missing_ok)
+    return HdfsPath(path).remove(missing_ok=missing_ok)
 
 
 def hdfs_scan(
@@ -190,7 +190,7 @@ def hdfs_scan(
     :raises: UnsupportedError
     :returns: A file path generator
     """
-    return HdfsPath(path).scan(missing_ok, followlinks)
+    return HdfsPath(path).scan(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def hdfs_scan_stat(
@@ -206,7 +206,7 @@ def hdfs_scan_stat(
     :raises: UnsupportedError
     :returns: A file path generator
     """
-    return HdfsPath(path).scan_stat(missing_ok, followlinks)
+    return HdfsPath(path).scan_stat(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def hdfs_scandir(path: PathLike) -> Iterator[FileEntry]:
@@ -228,7 +228,7 @@ def hdfs_unlink(path: PathLike, missing_ok: bool = False) -> None:
     :param missing_ok: if False and target file not exists, raise FileNotFoundError
     :raises: FileNotFoundError, IsADirectoryError
     """
-    return HdfsPath(path).unlink(missing_ok)
+    return HdfsPath(path).unlink(missing_ok=missing_ok)
 
 
 def hdfs_walk(
@@ -263,7 +263,7 @@ def hdfs_walk(
         Because hdfs not support symlink.
     :returns: A 3-tuple generator
     """
-    return HdfsPath(path).walk(followlinks)
+    return HdfsPath(path).walk(followlinks=followlinks)
 
 
 def hdfs_getmd5(
@@ -277,7 +277,7 @@ def hdfs_getmd5(
     :param followlinks: Ignore this parameter, just for compatibility
     :returns: checksum
     """
-    return HdfsPath(path).md5(recalculate, followlinks)
+    return HdfsPath(path).md5(recalculate=recalculate, followlinks=followlinks)
 
 
 def hdfs_save_as(file_object: BinaryIO, path: PathLike):

--- a/tests/compat/http.py
+++ b/tests/compat/http.py
@@ -71,7 +71,7 @@ def http_stat(path: PathLike, follow_symlinks=True) -> StatResult:
     :returns: StatResult
     :raises: HttpPermissionError, HttpFileNotFoundError
     """
-    return HttpPath(path).stat(follow_symlinks)
+    return HttpPath(path).stat(follow_symlinks=follow_symlinks)
 
 
 def http_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
@@ -85,7 +85,7 @@ def http_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
     :returns: File size (in bytes)
     :raises: HttpPermissionError, HttpFileNotFoundError
     """
-    return HttpPath(path).getsize(follow_symlinks)
+    return HttpPath(path).getsize(follow_symlinks=follow_symlinks)
 
 
 def http_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
@@ -99,7 +99,7 @@ def http_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
     :returns: Last-Modified time (in Unix timestamp format)
     :raises: HttpPermissionError, HttpFileNotFoundError
     """
-    return HttpPath(path).getmtime(follow_symlinks)
+    return HttpPath(path).getmtime(follow_symlinks=follow_symlinks)
 
 
 def http_exists(path: PathLike, followlinks: bool = False) -> bool:
@@ -111,4 +111,4 @@ def http_exists(path: PathLike, followlinks: bool = False) -> bool:
     :return: return True if exists
     :rtype: bool
     """
-    return HttpPath(path).exists(followlinks)
+    return HttpPath(path).exists(followlinks=followlinks)

--- a/tests/compat/s3.py
+++ b/tests/compat/s3.py
@@ -92,7 +92,7 @@ def s3_exists(path: PathLike, followlinks: bool = False) -> bool:
     :param path: Given path
     :returns: True if s3_url exists, else False
     """
-    return S3Path(path).exists(followlinks)
+    return S3Path(path).exists(followlinks=followlinks)
 
 
 def s3_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
@@ -110,7 +110,7 @@ def s3_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
     :returns: Last-modified time
     :raises: S3FileNotFoundError, UnsupportedError
     """
-    return S3Path(path).getmtime(follow_symlinks)
+    return S3Path(path).getmtime(follow_symlinks=follow_symlinks)
 
 
 def s3_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
@@ -130,7 +130,7 @@ def s3_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
     :returns: File size
     :raises: S3FileNotFoundError, UnsupportedError
     """
-    return S3Path(path).getsize(follow_symlinks)
+    return S3Path(path).getsize(follow_symlinks=follow_symlinks)
 
 
 def s3_isdir(path: PathLike, followlinks: bool = False) -> bool:
@@ -145,7 +145,7 @@ def s3_isdir(path: PathLike, followlinks: bool = False) -> bool:
         Because s3 symlink not support dir.
     :returns: True if path is s3 directory, else False
     """
-    return S3Path(path).is_dir(followlinks)
+    return S3Path(path).is_dir(followlinks=followlinks)
 
 
 def s3_isfile(path: PathLike, followlinks: bool = False) -> bool:
@@ -155,7 +155,7 @@ def s3_isfile(path: PathLike, followlinks: bool = False) -> bool:
     :param path: Given path
     :returns: True if path is s3 file, else False
     """
-    return S3Path(path).is_file(followlinks)
+    return S3Path(path).is_file(followlinks=followlinks)
 
 
 def s3_listdir(path: PathLike) -> List[str]:
@@ -198,7 +198,7 @@ def s3_move(src_url: PathLike, dst_url: PathLike, overwrite: bool = True) -> Non
     :param dst_url: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    return S3Path(src_url).move(dst_url, overwrite)
+    return S3Path(src_url).move(dst_url, overwrite=overwrite)
 
 
 def s3_remove(path: PathLike, missing_ok: bool = False) -> None:
@@ -211,7 +211,7 @@ def s3_remove(path: PathLike, missing_ok: bool = False) -> None:
         raise S3FileNotFoundError
     :raises: S3PermissionError, S3FileNotFoundError, UnsupportedError
     """
-    return S3Path(path).remove(missing_ok)
+    return S3Path(path).remove(missing_ok=missing_ok)
 
 
 def s3_scan(
@@ -238,7 +238,7 @@ def s3_scan(
     :raises: UnsupportedError
     :returns: A file path generator
     """
-    return S3Path(path).scan(missing_ok, followlinks)
+    return S3Path(path).scan(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def s3_scan_stat(
@@ -254,7 +254,7 @@ def s3_scan_stat(
     :raises: UnsupportedError
     :returns: A file path generator
     """
-    return S3Path(path).scan_stat(missing_ok, followlinks)
+    return S3Path(path).scan_stat(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def s3_scandir(path: PathLike) -> Iterator[FileEntry]:
@@ -283,7 +283,7 @@ def s3_stat(path: PathLike, follow_symlinks=True) -> StatResult:
     :returns: StatResult
     :raises: S3FileNotFoundError, S3BucketNotFoundError
     """
-    return S3Path(path).stat(follow_symlinks)
+    return S3Path(path).stat(follow_symlinks=follow_symlinks)
 
 
 def s3_unlink(path: PathLike, missing_ok: bool = False) -> None:
@@ -295,7 +295,7 @@ def s3_unlink(path: PathLike, missing_ok: bool = False) -> None:
         raise S3FileNotFoundError
     :raises: S3PermissionError, S3FileNotFoundError, S3IsADirectoryError
     """
-    return S3Path(path).unlink(missing_ok)
+    return S3Path(path).unlink(missing_ok=missing_ok)
 
 
 def s3_walk(
@@ -333,7 +333,7 @@ def s3_walk(
     :raises: UnsupportedError
     :returns: A 3-tuple generator
     """
-    return S3Path(path).walk(followlinks)
+    return S3Path(path).walk(followlinks=followlinks)
 
 
 def s3_getmd5(
@@ -349,7 +349,7 @@ def s3_getmd5(
     :param followlinks: If is True, calculate md5 for real file
     :returns: md5 meta info
     """
-    return S3Path(path).md5(recalculate, followlinks)
+    return S3Path(path).md5(recalculate=recalculate, followlinks=followlinks)
 
 
 def s3_sync(
@@ -369,7 +369,9 @@ def s3_sync(
         priority is higher than 'overwrite', default is False
     :param overwrite: whether or not overwrite file when exists, default is True
     """
-    return S3Path(src_url).sync(dst_url, followlinks, force, overwrite)
+    return S3Path(src_url).sync(
+        dst_url, followlinks=followlinks, force=force, overwrite=overwrite
+    )
 
 
 def s3_symlink(src_path: PathLike, dst_path: PathLike) -> None:
@@ -422,7 +424,7 @@ def s3_rename(src_url: PathLike, dst_url: PathLike, overwrite: bool = True) -> N
     :param dst_url: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    S3Path(src_url).rename(dst_url, overwrite)
+    S3Path(src_url).rename(dst_url, overwrite=overwrite)
 
 
 def s3_glob(

--- a/tests/compat/sftp.py
+++ b/tests/compat/sftp.py
@@ -179,7 +179,7 @@ def sftp_resolve(path: PathLike, strict=False) -> "str":
         eliminating any symbolic links encountered in the path.
     :rtype: SftpPath
     """
-    return SftpPath(path).resolve(strict).path_with_protocol
+    return SftpPath(path).resolve(strict=strict).path_with_protocol
 
 
 def sftp_path_join(path: PathLike, *other_paths: PathLike) -> str:
@@ -222,7 +222,7 @@ def sftp_exists(path: PathLike, followlinks: bool = False) -> bool:
     :returns: True if the path exists, else False
 
     """
-    return SftpPath(path).exists(followlinks)
+    return SftpPath(path).exists(followlinks=followlinks)
 
 
 def sftp_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
@@ -235,7 +235,7 @@ def sftp_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
     :param path: Given path
     :returns: last-modified time
     """
-    return SftpPath(path).getmtime(follow_symlinks)
+    return SftpPath(path).getmtime(follow_symlinks=follow_symlinks)
 
 
 def sftp_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
@@ -252,7 +252,7 @@ def sftp_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
     :returns: File size
 
     """
-    return SftpPath(path).getsize(follow_symlinks)
+    return SftpPath(path).getsize(follow_symlinks=follow_symlinks)
 
 
 def sftp_isdir(path: PathLike, followlinks: bool = False) -> bool:
@@ -269,7 +269,7 @@ def sftp_isdir(path: PathLike, followlinks: bool = False) -> bool:
     :returns: True if the path is a directory, else False
 
     """
-    return SftpPath(path).is_dir(followlinks)
+    return SftpPath(path).is_dir(followlinks=followlinks)
 
 
 def sftp_isfile(path: PathLike, followlinks: bool = False) -> bool:
@@ -286,7 +286,7 @@ def sftp_isfile(path: PathLike, followlinks: bool = False) -> bool:
     :returns: True if the path is a file, else False
 
     """
-    return SftpPath(path).is_file(followlinks)
+    return SftpPath(path).is_file(followlinks=followlinks)
 
 
 def sftp_listdir(path: PathLike) -> List[str]:
@@ -328,7 +328,7 @@ def sftp_makedirs(
 
     :raises: FileExistsError
     """
-    return SftpPath(path).mkdir(mode, parents, exist_ok)
+    return SftpPath(path).mkdir(mode, parents=parents, exist_ok=exist_ok)
 
 
 def sftp_realpath(path: PathLike) -> str:
@@ -350,7 +350,7 @@ def sftp_rename(
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    return SftpPath(src_path).rename(dst_path, overwrite)
+    return SftpPath(src_path).rename(dst_path, overwrite=overwrite)
 
 
 def sftp_move(
@@ -363,7 +363,7 @@ def sftp_move(
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    return SftpPath(src_path).replace(dst_path, overwrite)
+    return SftpPath(src_path).replace(dst_path, overwrite=overwrite)
 
 
 def sftp_remove(path: PathLike, missing_ok: bool = False) -> None:
@@ -374,7 +374,7 @@ def sftp_remove(path: PathLike, missing_ok: bool = False) -> None:
     :param missing_ok: if False and target file/directory not exists,
         raise FileNotFoundError
     """
-    return SftpPath(path).remove(missing_ok)
+    return SftpPath(path).remove(missing_ok=missing_ok)
 
 
 def sftp_scan(
@@ -393,7 +393,7 @@ def sftp_scan(
         raise FileNotFoundError
     :returns: A file path generator
     """
-    return SftpPath(path).scan(missing_ok, followlinks)
+    return SftpPath(path).scan(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def sftp_scan_stat(
@@ -408,7 +408,7 @@ def sftp_scan_stat(
         raise FileNotFoundError
     :returns: A file path generator
     """
-    return SftpPath(path).scan_stat(missing_ok, followlinks)
+    return SftpPath(path).scan_stat(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def sftp_scandir(path: PathLike) -> Iterator[FileEntry]:
@@ -429,7 +429,7 @@ def sftp_stat(path: PathLike, follow_symlinks=True) -> StatResult:
     :param path: Given path
     :returns: StatResult
     """
-    return SftpPath(path).stat(follow_symlinks)
+    return SftpPath(path).stat(follow_symlinks=follow_symlinks)
 
 
 def sftp_unlink(path: PathLike, missing_ok: bool = False) -> None:
@@ -439,7 +439,7 @@ def sftp_unlink(path: PathLike, missing_ok: bool = False) -> None:
     :param path: Given path
     :param missing_ok: if False and target file not exists, raise FileNotFoundError
     """
-    return SftpPath(path).unlink(missing_ok)
+    return SftpPath(path).unlink(missing_ok=missing_ok)
 
 
 def sftp_walk(
@@ -469,7 +469,7 @@ def sftp_walk(
     :param followlinks: False if regard symlink as file, else True
     :returns: A 3-tuple generator
     """
-    return SftpPath(path).walk(followlinks)
+    return SftpPath(path).walk(followlinks=followlinks)
 
 
 def sftp_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = False):
@@ -482,7 +482,7 @@ def sftp_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = F
 
     returns: md5 of file
     """
-    return SftpPath(path).md5(recalculate, followlinks)
+    return SftpPath(path).md5(recalculate=recalculate, followlinks=followlinks)
 
 
 def sftp_symlink(src_path: PathLike, dst_path: PathLike) -> None:
@@ -583,4 +583,6 @@ def sftp_sync(
         priority is higher than 'overwrite', default is False
     :param overwrite: whether or not overwrite file when exists, default is True
     """
-    return SftpPath(src_path).sync(dst_path, followlinks, force, overwrite)
+    return SftpPath(src_path).sync(
+        dst_path, followlinks=followlinks, force=force, overwrite=overwrite
+    )

--- a/tests/compat/sftp2.py
+++ b/tests/compat/sftp2.py
@@ -185,7 +185,7 @@ def sftp2_resolve(path: PathLike, strict=False) -> "str":
         eliminating any symbolic links encountered in the path.
     :rtype: Sftp2Path
     """
-    return Sftp2Path(path).resolve(strict).path_with_protocol
+    return Sftp2Path(path).resolve(strict=strict).path_with_protocol
 
 
 def sftp2_download(
@@ -373,7 +373,7 @@ def sftp2_exists(path: PathLike, followlinks: bool = False) -> bool:
     :returns: True if the path exists, else False
 
     """
-    return Sftp2Path(path).exists(followlinks)
+    return Sftp2Path(path).exists(followlinks=followlinks)
 
 
 def sftp2_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
@@ -386,7 +386,7 @@ def sftp2_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
     :param path: Given path
     :returns: last-modified time
     """
-    return Sftp2Path(path).getmtime(follow_symlinks)
+    return Sftp2Path(path).getmtime(follow_symlinks=follow_symlinks)
 
 
 def sftp2_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
@@ -403,7 +403,7 @@ def sftp2_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
     :returns: File size
 
     """
-    return Sftp2Path(path).getsize(follow_symlinks)
+    return Sftp2Path(path).getsize(follow_symlinks=follow_symlinks)
 
 
 def sftp2_isdir(path: PathLike, followlinks: bool = False) -> bool:
@@ -420,7 +420,7 @@ def sftp2_isdir(path: PathLike, followlinks: bool = False) -> bool:
     :returns: True if the path is a directory, else False
 
     """
-    return Sftp2Path(path).is_dir(followlinks)
+    return Sftp2Path(path).is_dir(followlinks=followlinks)
 
 
 def sftp2_isfile(path: PathLike, followlinks: bool = False) -> bool:
@@ -437,7 +437,7 @@ def sftp2_isfile(path: PathLike, followlinks: bool = False) -> bool:
     :returns: True if the path is a file, else False
 
     """
-    return Sftp2Path(path).is_file(followlinks)
+    return Sftp2Path(path).is_file(followlinks=followlinks)
 
 
 def sftp2_listdir(path: PathLike) -> List[str]:
@@ -479,7 +479,7 @@ def sftp2_makedirs(
 
     :raises: FileExistsError
     """
-    return Sftp2Path(path).mkdir(mode, parents, exist_ok)
+    return Sftp2Path(path).mkdir(mode, parents=parents, exist_ok=exist_ok)
 
 
 def sftp2_realpath(path: PathLike) -> str:
@@ -501,7 +501,7 @@ def sftp2_rename(
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    return Sftp2Path(src_path).rename(dst_path, overwrite)
+    return Sftp2Path(src_path).rename(dst_path, overwrite=overwrite)
 
 
 def sftp2_move(
@@ -514,7 +514,7 @@ def sftp2_move(
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    return Sftp2Path(src_path).replace(dst_path, overwrite)
+    return Sftp2Path(src_path).replace(dst_path, overwrite=overwrite)
 
 
 def sftp2_remove(path: PathLike, missing_ok: bool = False) -> None:
@@ -525,7 +525,7 @@ def sftp2_remove(path: PathLike, missing_ok: bool = False) -> None:
     :param missing_ok: if False and target file/directory not exists,
         raise FileNotFoundError
     """
-    return Sftp2Path(path).remove(missing_ok)
+    return Sftp2Path(path).remove(missing_ok=missing_ok)
 
 
 def sftp2_scan(
@@ -544,7 +544,7 @@ def sftp2_scan(
         raise FileNotFoundError
     :returns: A file path generator
     """
-    return Sftp2Path(path).scan(missing_ok, followlinks)
+    return Sftp2Path(path).scan(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def sftp2_scan_stat(
@@ -559,7 +559,7 @@ def sftp2_scan_stat(
         raise FileNotFoundError
     :returns: A file path generator
     """
-    return Sftp2Path(path).scan_stat(missing_ok, followlinks)
+    return Sftp2Path(path).scan_stat(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def sftp2_scandir(path: PathLike) -> Iterator[FileEntry]:
@@ -580,7 +580,7 @@ def sftp2_stat(path: PathLike, follow_symlinks=True) -> StatResult:
     :param path: Given path
     :returns: StatResult
     """
-    return Sftp2Path(path).stat(follow_symlinks)
+    return Sftp2Path(path).stat(follow_symlinks=follow_symlinks)
 
 
 def sftp2_unlink(path: PathLike, missing_ok: bool = False) -> None:
@@ -590,7 +590,7 @@ def sftp2_unlink(path: PathLike, missing_ok: bool = False) -> None:
     :param path: Given path
     :param missing_ok: if False and target file not exists, raise FileNotFoundError
     """
-    return Sftp2Path(path).unlink(missing_ok)
+    return Sftp2Path(path).unlink(missing_ok=missing_ok)
 
 
 def sftp2_walk(
@@ -620,7 +620,7 @@ def sftp2_walk(
     :param followlinks: False if regard symlink as file, else True
     :returns: A 3-tuple generator
     """
-    return Sftp2Path(path).walk(followlinks)
+    return Sftp2Path(path).walk(followlinks=followlinks)
 
 
 def sftp2_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = False):
@@ -633,7 +633,7 @@ def sftp2_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = 
 
     returns: md5 of file
     """
-    return Sftp2Path(path).md5(recalculate, followlinks)
+    return Sftp2Path(path).md5(recalculate=recalculate, followlinks=followlinks)
 
 
 def sftp2_symlink(src_path: PathLike, dst_path: PathLike) -> None:
@@ -737,7 +737,9 @@ def sftp2_copy(
     :raises IsADirectoryError: If the source is a directory.
     :raises OSError: If there is an error copying the file.
     """
-    return Sftp2Path(src_path).copy(dst_path, callback, followlinks, overwrite)
+    return Sftp2Path(src_path).copy(
+        dst_path, callback, followlinks=followlinks, overwrite=overwrite
+    )
 
 
 def sftp2_sync(
@@ -756,7 +758,9 @@ def sftp2_sync(
         priority is higher than 'overwrite', default is False
     :param overwrite: whether or not overwrite file when exists, default is True
     """
-    return Sftp2Path(src_path).sync(dst_path, followlinks, force, overwrite)
+    return Sftp2Path(src_path).sync(
+        dst_path, followlinks=followlinks, force=force, overwrite=overwrite
+    )
 
 
 def _check_input(input_str: str, fingerprint: str, times: int = 0) -> bool:

--- a/tests/compat/webdav.py
+++ b/tests/compat/webdav.py
@@ -106,7 +106,7 @@ def webdav_resolve(path: PathLike, strict=False) -> "str":
     :param strict: Ignored for WebDAV
     :return: Absolute path
     """
-    return WebdavPath(path).resolve(strict).path_with_protocol
+    return WebdavPath(path).resolve(strict=strict).path_with_protocol
 
 
 def webdav_download(
@@ -244,7 +244,7 @@ def webdav_exists(path: PathLike, followlinks: bool = False) -> bool:
     :param followlinks: Ignored for WebDAV
     :returns: True if the path exists, else False
     """
-    return WebdavPath(path).exists(followlinks)
+    return WebdavPath(path).exists(followlinks=followlinks)
 
 
 def webdav_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
@@ -255,7 +255,7 @@ def webdav_getmtime(path: PathLike, follow_symlinks: bool = False) -> float:
     :param follow_symlinks: Ignored for WebDAV
     :returns: last-modified time
     """
-    return WebdavPath(path).getmtime(follow_symlinks)
+    return WebdavPath(path).getmtime(follow_symlinks=follow_symlinks)
 
 
 def webdav_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
@@ -266,7 +266,7 @@ def webdav_getsize(path: PathLike, follow_symlinks: bool = False) -> int:
     :param follow_symlinks: Ignored for WebDAV
     :returns: File size
     """
-    return WebdavPath(path).getsize(follow_symlinks)
+    return WebdavPath(path).getsize(follow_symlinks=follow_symlinks)
 
 
 def webdav_isdir(path: PathLike, followlinks: bool = False) -> bool:
@@ -277,7 +277,7 @@ def webdav_isdir(path: PathLike, followlinks: bool = False) -> bool:
     :param followlinks: Ignored for WebDAV
     :returns: True if the path is a directory, else False
     """
-    return WebdavPath(path).is_dir(followlinks)
+    return WebdavPath(path).is_dir(followlinks=followlinks)
 
 
 def webdav_isfile(path: PathLike, followlinks: bool = False) -> bool:
@@ -288,7 +288,7 @@ def webdav_isfile(path: PathLike, followlinks: bool = False) -> bool:
     :param followlinks: Ignored for WebDAV
     :returns: True if the path is a file, else False
     """
-    return WebdavPath(path).is_file(followlinks)
+    return WebdavPath(path).is_file(followlinks=followlinks)
 
 
 def webdav_listdir(path: PathLike) -> List[str]:
@@ -324,7 +324,7 @@ def webdav_makedirs(
     :param parents: If parents is true, any missing parents are created
     :param exist_ok: If False and target directory exists, raise FileExistsError
     """
-    return WebdavPath(path).mkdir(mode, parents, exist_ok)
+    return WebdavPath(path).mkdir(mode, parents=parents, exist_ok=exist_ok)
 
 
 def webdav_realpath(path: PathLike) -> str:
@@ -346,7 +346,7 @@ def webdav_rename(
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    return WebdavPath(src_path).rename(dst_path, overwrite)
+    return WebdavPath(src_path).rename(dst_path, overwrite=overwrite)
 
 
 def webdav_move(
@@ -359,7 +359,7 @@ def webdav_move(
     :param dst_path: Given destination path
     :param overwrite: whether or not overwrite file when exists
     """
-    return WebdavPath(src_path).replace(dst_path, overwrite)
+    return WebdavPath(src_path).replace(dst_path, overwrite=overwrite)
 
 
 def webdav_remove(path: PathLike, missing_ok: bool = False) -> None:
@@ -370,7 +370,7 @@ def webdav_remove(path: PathLike, missing_ok: bool = False) -> None:
     :param missing_ok: if False and target file/directory not exists,
         raise FileNotFoundError
     """
-    return WebdavPath(path).remove(missing_ok)
+    return WebdavPath(path).remove(missing_ok=missing_ok)
 
 
 def webdav_scan(
@@ -385,7 +385,7 @@ def webdav_scan(
     :param followlinks: Ignored for WebDAV
     :returns: A file path generator
     """
-    return WebdavPath(path).scan(missing_ok, followlinks)
+    return WebdavPath(path).scan(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def webdav_scan_stat(
@@ -400,7 +400,7 @@ def webdav_scan_stat(
     :param followlinks: Ignored for WebDAV
     :returns: A file path generator yielding FileEntry objects
     """
-    return WebdavPath(path).scan_stat(missing_ok, followlinks)
+    return WebdavPath(path).scan_stat(missing_ok=missing_ok, followlinks=followlinks)
 
 
 def webdav_scandir(path: PathLike) -> Iterator[FileEntry]:
@@ -421,7 +421,7 @@ def webdav_stat(path: PathLike, follow_symlinks=True) -> StatResult:
     :param follow_symlinks: Ignored for WebDAV
     :returns: StatResult
     """
-    return WebdavPath(path).stat(follow_symlinks)
+    return WebdavPath(path).stat(follow_symlinks=follow_symlinks)
 
 
 def webdav_unlink(path: PathLike, missing_ok: bool = False) -> None:
@@ -431,7 +431,7 @@ def webdav_unlink(path: PathLike, missing_ok: bool = False) -> None:
     :param path: Given path
     :param missing_ok: if False and target file not exists, raise FileNotFoundError
     """
-    return WebdavPath(path).unlink(missing_ok)
+    return WebdavPath(path).unlink(missing_ok=missing_ok)
 
 
 def webdav_walk(
@@ -444,7 +444,7 @@ def webdav_walk(
     :param followlinks: Ignored for WebDAV
     :returns: A 3-tuple generator (root, dirs, files)
     """
-    return WebdavPath(path).walk(followlinks)
+    return WebdavPath(path).walk(followlinks=followlinks)
 
 
 def webdav_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool = False):
@@ -456,7 +456,7 @@ def webdav_getmd5(path: PathLike, recalculate: bool = False, followlinks: bool =
     :param followlinks: Ignored for WebDAV
     :returns: md5 of file
     """
-    return WebdavPath(path).md5(recalculate, followlinks)
+    return WebdavPath(path).md5(recalculate=recalculate, followlinks=followlinks)
 
 
 def webdav_save_as(file_object: BinaryIO, path: PathLike):
@@ -526,7 +526,9 @@ def webdav_copy(
     :param followlinks: Ignored for WebDAV
     :param overwrite: whether to overwrite existing file
     """
-    return WebdavPath(src_path).copy(dst_path, callback, followlinks, overwrite)
+    return WebdavPath(src_path).copy(
+        dst_path, callback, followlinks=followlinks, overwrite=overwrite
+    )
 
 
 def webdav_sync(
@@ -544,4 +546,6 @@ def webdav_sync(
     :param force: Sync file forcibly
     :param overwrite: whether or not overwrite file when exists, default is True
     """
-    return WebdavPath(src_path).sync(dst_path, followlinks, force, overwrite)
+    return WebdavPath(src_path).sync(
+        dst_path, followlinks=followlinks, force=force, overwrite=overwrite
+    )

--- a/tests/test_smart.py
+++ b/tests/test_smart.py
@@ -551,11 +551,11 @@ def test_smart_rename_fs(s3_empty_client, filesystem):
 def test_smart_unlink(funcA):
     funcA.return_value = None
 
-    res = smart.smart_unlink("False Case", False)
+    res = smart.smart_unlink("False Case", missing_ok=False)
     assert res is None
     funcA.assert_called_once_with(missing_ok=False)
 
-    res = smart.smart_unlink("True Case", True)
+    res = smart.smart_unlink("True Case", missing_ok=True)
     assert res is None
     funcA.assert_called_with(missing_ok=True)
 
@@ -565,7 +565,7 @@ def test_smart_makedirs(funcA):
     funcA.return_value = None
     res = smart.smart_makedirs("Test Case", exist_ok=True)
     assert res is None
-    funcA.assert_called_once_with(True)
+    funcA.assert_called_once_with(exist_ok=True)
 
 
 def test_smart_open_input_params(mocker, fs):


### PR DESCRIPTION
## Summary
- pass bool-style flags by keyword in megfile path/compat helper calls
- keep non-flag positional arguments unchanged
- leave standard default-value calls such as dict.get/getattr/setattr untouched

## Validation
- make style_check
- make static_check
- pytest tests/test_smart.py::test_smart_makedirs tests/test_fs.py::test_fs_rename tests/test_s3.py::test_s3_rename tests/test_webdav.py::test_webdav_rename -q