### PR TITLE
refactor: reduce WebDAV stat checks (round 2)

### DIFF
--- a/megfile/lib/webdav_memory_handler.py
+++ b/megfile/lib/webdav_memory_handler.py
@@ -2,10 +2,7 @@ import os
 
 from webdav3.client import Client as WebdavClient
 from webdav3.client import Urn, WebDavXmlUtils, wrap_connection_error
-from webdav3.exceptions import (
-    OptionNotValid,
-    RemoteResourceNotFound,
-)
+from webdav3.exceptions import RemoteResourceNotFound
 
 from megfile.lib.base_memory_handler import BaseMemoryHandler
 from megfile.pathlike import UNKNOWN_STAT
@@ -27,15 +24,8 @@ def _webdav_stat(client: WebdavClient, remote_path: str):
 
 
 @wrap_connection_error
-def _webdav_download_from(client: WebdavClient, buff, remote_path, *, check=True):
+def _webdav_download_from(client: WebdavClient, buff, remote_path):
     urn = Urn(remote_path)
-    if check:
-        if client.is_dir(urn.path()):
-            raise OptionNotValid(name="remote_path", value=remote_path)
-
-        if not client.check(urn.path()):
-            raise RemoteResourceNotFound(urn.path())
-
     response = client.execute_request(action="download", path=urn.quote())
 
     for chunk in response.iter_content(chunk_size=client.chunk_size):
@@ -78,7 +68,6 @@ class WebdavMemoryHandler(BaseMemoryHandler):
             self._client,
             self._fileobj,
             self._remote_path,
-            check=self._content_stat is UNKNOWN_STAT,
         )
         if self._mode[0] == "r":
             self.seek(0, os.SEEK_SET)

--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -270,11 +270,6 @@ def _webdav_scan_pairs(
 
 def _webdav_scan(client: WebdavClient, remote_path: str) -> List[dict]:
     directory_urn = Urn(remote_path, directory=True)
-    if directory_urn.path() != WebdavClient.root and not client.check(
-        directory_urn.path()
-    ):
-        raise RemoteResourceNotFound(directory_urn.path())
-
     path = Urn.normalize_path(client.get_full_path(directory_urn))
     response = client.execute_request(
         action="list", path=directory_urn.quote(), headers_ext=["Depth: infinity"]
@@ -755,13 +750,15 @@ class WebdavPath(URIPath):
         if stat is None or stat.is_file():
             return
 
-        stack = [self._remote_path]
+        stack = [self]
         while stack:
-            root = stack.pop()
+            root_path = stack.pop()
             dirs, files = [], []
 
-            root_path = self._generate_path_object(root)
-            for entry in root_path.scandir():
+            for info in _webdav_scandir(root_path._client, root_path._remote_path):
+                entry = _make_entry(
+                    info, root_path._remote_path, root_path.path_with_protocol
+                )
                 if entry.is_dir():
                     dirs.append(entry.name)
                 else:
@@ -772,9 +769,7 @@ class WebdavPath(URIPath):
 
             yield root_path.path_with_protocol, dirs, files
 
-            stack.extend(
-                (os.path.join(root, directory) for directory in reversed(dirs))
-            )
+            stack.extend(root_path.joinpath(directory) for directory in reversed(dirs))
 
     def resolve(self, strict=False) -> "WebdavPath":
         """Return the absolute path

--- a/tests/lib/test_webdav_memory_handler.py
+++ b/tests/lib/test_webdav_memory_handler.py
@@ -24,7 +24,7 @@ def client(fs, mocker):
     def fake_webdav_stat(client, path: str) -> Dict:
         return client.info(path)
 
-    def fake_webdav_download_from(client, buff, path: str, *, check=True) -> Dict:
+    def fake_webdav_download_from(client, buff, path: str) -> Dict:
         return client.download_from(buff, path)
 
     mocker.patch(
@@ -90,34 +90,12 @@ def test_webdav_download_from_function(real_webdav_client, mocker):
     mock_response.iter_content.return_value = [b"chunk1", b"chunk2", b"chunk3"]
 
     real_webdav_client.execute_request.return_value = mock_response
-    real_webdav_client.is_dir.return_value = False
-    real_webdav_client.check.return_value = True
-
     buffer = BytesIO()
     _webdav_download_from(real_webdav_client, buffer, "/test/file.txt")
 
     assert buffer.getvalue() == b"chunk1chunk2chunk3"
-
-
-def test_webdav_download_from_is_directory(real_webdav_client, mocker):
-    """Test _webdav_download_from raises error for directory"""
-    from webdav3.exceptions import OptionNotValid
-
-    real_webdav_client.is_dir.return_value = True
-
-    buffer = BytesIO()
-    with pytest.raises(OptionNotValid):
-        _webdav_download_from(real_webdav_client, buffer, "/test/dir")
-
-
-def test_webdav_download_from_not_found(real_webdav_client, mocker):
-    """Test _webdav_download_from raises error for non-existent file"""
-    real_webdav_client.is_dir.return_value = False
-    real_webdav_client.check.return_value = False
-
-    buffer = BytesIO()
-    with pytest.raises(RemoteResourceNotFound):
-        _webdav_download_from(real_webdav_client, buffer, "/test/notfound.txt")
+    real_webdav_client.is_dir.assert_not_called()
+    real_webdav_client.check.assert_not_called()
 
 
 def test_webdav_memory_handler_close(client):

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -26,6 +26,7 @@ class FakeWebdavClient:
     def __init__(self, options: dict = {}):
         self.options = options
         self.info_calls = []
+        self.check_calls = []
 
     def _relative_path(self, path: str) -> str:
         # XXX: pyfakefs not work in python3.14 when path is absolute
@@ -39,6 +40,7 @@ class FakeWebdavClient:
 
     def check(self, path: str) -> bool:
         """Check if path exists"""
+        self.check_calls.append(path)
         path = self._relative_path(path)
         return os.path.exists(path)
 
@@ -158,7 +160,7 @@ def webdav_mocker(fs, mocker):
                 yield from fake_webdav_scan(client, info["path"])
             yield info
 
-    def fake_webdav_download_from(client, buff, path: str, *, check=True) -> Dict:
+    def fake_webdav_download_from(client, buff, path: str) -> Dict:
         return client.download_from(buff, path)
 
     mocker.patch(
@@ -488,11 +490,47 @@ def test_webdav_scandir_reuses_stat(webdav_mocker):
     path = webdav.WebdavPath("webdav://host/A")
     client = path._client
     client.info_calls.clear()
+    client.check_calls.clear()
 
     with path.scandir() as entries:
         assert list(entries) == []
 
     assert client.info_calls == ["/A"]
+    assert client.check_calls == []
+
+
+def test_webdav_open_read_reuses_stat(webdav_mocker):
+    webdav.webdav_makedirs("webdav://host/A")
+    with webdav.webdav_open("webdav://host/A/1.json", "w") as f:
+        f.write("1.json")
+
+    path = webdav.WebdavPath("webdav://host/A/1.json")
+    client = path._client
+    client.info_calls.clear()
+    client.check_calls.clear()
+
+    with path.open("r") as f:
+        assert f.read() == "1.json"
+
+    assert client.info_calls == ["/A/1.json"]
+    assert client.check_calls == []
+
+
+def test_webdav_scan_stat_directory_skips_extra_check(webdav_mocker):
+    webdav.webdav_makedirs("webdav://host/A")
+    with webdav.webdav_open("webdav://host/A/1.json", "w") as f:
+        f.write("1.json")
+
+    path = webdav.WebdavPath("webdav://host/A")
+    client = path._client
+    client.info_calls.clear()
+    client.check_calls.clear()
+
+    entries = list(path.scan_stat())
+
+    assert [entry.path for entry in entries] == ["webdav://host/A/1.json"]
+    assert client.info_calls == ["/A"]
+    assert client.check_calls == []
 
 
 def test_webdav_unlink(webdav_mocker):
@@ -539,13 +577,17 @@ def test_webdav_walk(webdav_mocker):
     with webdav.webdav_open("webdav://host/A/b/3.json", "w") as f:
         f.write("3.json")
 
-    assert list(webdav.webdav_walk("webdav://host/A")) == [
+    path = webdav.WebdavPath("webdav://host/A")
+    client = path._client
+    client.info_calls.clear()
+    assert list(path.walk()) == [
         ("webdav://host/A", ["a", "b"], ["1.json"]),
         ("webdav://host/A/a", ["b"], ["2.json"]),
         ("webdav://host/A/a/b", [], []),
         ("webdav://host/A/b", ["c"], ["3.json"]),
         ("webdav://host/A/b/c", [], []),
     ]
+    assert client.info_calls == ["/A"]
 
     assert list(webdav.webdav_walk("webdav://host/A/not_found")) == []
     assert list(webdav.webdav_walk("webdav://host/A/1.json")) == []

--- a/tests/test_webdav_path.py
+++ b/tests/test_webdav_path.py
@@ -626,18 +626,29 @@ def test_iterdir_on_file(webdav_mocker):
         list(WebdavPath("webdav://host/file.txt").iterdir())
 
 
-def test_open_directory_raises_error(webdav_mocker):
+def test_open_directory_raises_error(webdav_mocker, mocker):
     """Test open on directory raises error"""
     webdav.webdav_makedirs("webdav://host/A")
+    download_from = mocker.patch(
+        "megfile.lib.webdav_memory_handler._webdav_download_from"
+    )
 
     with pytest.raises(IsADirectoryError):
         webdav.webdav_open("webdav://host/A", "w")
+    with pytest.raises(IsADirectoryError):
+        webdav.webdav_open("webdav://host/A", "r")
+    download_from.assert_not_called()
 
 
-def test_open_nonexistent_for_read_raises_error(webdav_mocker):
+def test_open_nonexistent_for_read_raises_error(webdav_mocker, mocker):
     """Test open non-existent file for read raises error"""
+    download_from = mocker.patch(
+        "megfile.lib.webdav_memory_handler._webdav_download_from"
+    )
+
     with pytest.raises(FileNotFoundError):
         webdav.webdav_open("webdav://host/nonexistent", "r")
+    download_from.assert_not_called()
 
 
 def test_walk_on_nonexistent(webdav_mocker):


### PR DESCRIPTION
## Summary
- keep low-level `_webdav_*` helpers focused on the actual WebDAV request instead of doing existence pre-checks
- rely on `WebdavPath` public methods to perform path-state checks before calling scan/scandir/download helpers
- avoid an extra per-directory stat in `walk` by listing known directories directly
- add request-count regression tests for `open`, `scan_stat`, `scandir`, and `walk`

## Validation
- `make style_check`
- `make static_check`
- `pytest tests/test_webdav.py::test_webdav_open_read_reuses_stat tests/test_webdav.py::test_webdav_walk tests/test_webdav.py::test_webdav_scan_stat_directory_skips_extra_check tests/test_webdav.py::test_webdav_scandir_reuses_stat tests/test_webdav.py::test_webdav_scan tests/test_webdav_path.py::test_open_nonexistent_for_read_raises_error tests/test_webdav_path.py::test_open_directory_raises_error tests/test_webdav_path.py::test_scandir_on_nonexistent_raises_error tests/test_webdav_path.py::test_scan_stat_missing_ok tests/lib/test_webdav_memory_handler.py::test_webdav_download_from_function tests/lib/test_webdav_memory_handler.py::test_webdav_memory_handler_file_exists_not_found -q`