### PR TITLE
perf: reduce SFTP stat calls

### DIFF
--- a/megfile/sftp2_path.py
+++ b/megfile/sftp2_path.py
@@ -7,7 +7,7 @@ import socket
 import subprocess
 from functools import cached_property
 from logging import getLogger as get_logger
-from stat import S_ISDIR, S_ISLNK, S_ISREG
+from stat import S_ISDIR, S_ISLNK
 from typing import IO, BinaryIO, Callable, Iterator, List, Optional, Tuple, Union
 from urllib.parse import urlsplit, urlunsplit
 
@@ -69,7 +69,7 @@ def get_private_key():
     private_key_path = os.getenv(SFTP_PRIVATE_KEY_PATH)
     if private_key_path:
         if not os.path.exists(private_key_path):
-            raise FileNotFoundError(f"Private key file not exist: '{private_key_path}'")
+            raise FileNotFoundError("Private key file not exist: %r" % private_key_path)
         private_key_password = os.getenv(SFTP_PRIVATE_KEY_PASSWORD)
         if private_key_password:
             return private_key_path, private_key_password
@@ -560,7 +560,7 @@ class Sftp2Path(URIPath):
         for remote_path in _create_missing_ok_generator(
             iglob(fspath(glob_path), recursive=recursive, fs=fs),
             missing_ok=missing_ok,
-            error=FileNotFoundError(f"No match any file: {glob_path!r}"),
+            error=FileNotFoundError("No match any file: %r" % glob_path),
         ):
             yield self.from_path(remote_path)
 
@@ -576,9 +576,7 @@ class Sftp2Path(URIPath):
         """Test if a path is file"""
         try:
             stat = self.stat(follow_symlinks=followlinks)
-            return (
-                S_ISREG(stat.st_mode) if hasattr(stat, "st_mode") else not stat.is_dir()
-            )
+            return stat.is_file()
         except FileNotFoundError:
             return False
 
@@ -603,7 +601,7 @@ class Sftp2Path(URIPath):
         """Make a directory on sftp2"""
         if self.exists():
             if not exist_ok:
-                raise FileExistsError(f"File exists: '{self.path_with_protocol}'")
+                raise FileExistsError("File exists: %r" % self.path_with_protocol)
             return
 
         if parents:
@@ -639,7 +637,7 @@ class Sftp2Path(URIPath):
     def rename(self, dst_path: PathLike, overwrite: bool = True) -> "Sftp2Path":
         """Rename file on sftp2"""
         if not self._is_same_protocol(dst_path):
-            raise OSError(f"Not a {self.protocol} path: {dst_path!r}")
+            raise OSError("Not a %s path: %r" % (self.protocol, dst_path))
 
         dst_path = self.from_path(str(dst_path).rstrip("/"))
         src_stat = self.stat()
@@ -651,6 +649,7 @@ class Sftp2Path(URIPath):
             else:
                 self.sync(dst_path, overwrite=overwrite)
                 self.remove(missing_ok=True)
+            return dst_path
         else:
             if self.is_dir():
                 for file_entry in self.scandir():
@@ -675,73 +674,32 @@ class Sftp2Path(URIPath):
 
     def remove(self, missing_ok: bool = False) -> None:
         """Remove the file or directory on sftp2"""
-        if missing_ok and not self.exists():
-            return
-        if self.is_dir():
-            for file_entry in self.scandir():
+        stat = self._stat_or_none(follow_symlinks=False)
+        if stat is None:
+            if missing_ok:
+                return
+            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+        if stat.is_dir():
+            for file_entry in self._scandir_with_stat(stat):
                 self.from_path(file_entry.path).remove(missing_ok=missing_ok)
             self._client.rmdir(self._remote_path)
         else:
             self._client.unlink(self._remote_path)
 
-    def scan(self, missing_ok: bool = True, followlinks: bool = False) -> Iterator[str]:
-        """Iteratively traverse only files in given directory"""
-        scan_stat_iter = self.scan_stat(missing_ok=missing_ok, followlinks=followlinks)
-        for file_entry in scan_stat_iter:
-            yield file_entry.path
-
-    def scan_stat(
-        self, missing_ok: bool = True, followlinks: bool = False
-    ) -> Iterator[FileEntry]:
-        """Iteratively traverse only files in given directory"""
-
-        def create_generator() -> Iterator[FileEntry]:
-            try:
-                stat = self.stat(follow_symlinks=followlinks)
-            except FileNotFoundError:
-                return
-            if not stat.is_dir():
-                yield FileEntry(
-                    self.name,
-                    self.path_with_protocol,
-                    self.stat(follow_symlinks=followlinks),
-                )
-                return
-
-            for name in self.listdir():
-                current_path = self.joinpath(name)
-                if current_path.is_dir():
-                    yield from current_path.scan_stat(
-                        missing_ok=missing_ok, followlinks=followlinks
-                    )
-                else:
-                    yield FileEntry(
-                        current_path.name,
-                        current_path.path_with_protocol,
-                        current_path.stat(follow_symlinks=followlinks),
-                    )
-
-        return _create_missing_ok_generator(
-            create_generator(),
-            missing_ok=missing_ok,
-            error=FileNotFoundError(
-                f"No match any file in: {self.path_with_protocol!r}"
-            ),
-        )
-
-    def scandir(self) -> ContextIterator:
-        """Get all content of given file path"""
+    def _scandir_with_stat(
+        self, stat: StatResult, follow_root_symlink: bool = False
+    ) -> ContextIterator:
+        """Get all content of a known existing path"""
         remote_path = self._remote_path
-        stat_result = None
-        try:
-            stat_result = self.stat(follow_symlinks=False)
-        except Exception:
-            raise NotADirectoryError(f"Not a directory: '{self.path_with_protocol}'")
-
-        if stat_result.is_symlink():
-            remote_path = self.readlink()._remote_path
-        elif not stat_result.is_dir():
-            raise NotADirectoryError(f"Not a directory: '{self.path_with_protocol}'")
+        if stat.is_symlink():
+            if follow_root_symlink:
+                stat = self.stat(follow_symlinks=True)
+            else:
+                raise NotADirectoryError(
+                    "Not a directory: %r" % self.path_with_protocol
+                )
+        if not stat.is_dir():
+            raise NotADirectoryError("Not a directory: %r" % self.path_with_protocol)
 
         def create_generator():
             # Use opendir and readdir from ssh2-python
@@ -769,6 +727,68 @@ class Sftp2Path(URIPath):
 
         return ContextIterator(create_generator())
 
+    def _scan_stat_with_stat(
+        self, stat: StatResult, missing_ok: bool, followlinks: bool
+    ) -> Iterator[FileEntry]:
+        if stat.is_file():
+            yield FileEntry(
+                self.name,
+                self.path_with_protocol,
+                stat,
+            )
+            return
+
+        with self._scandir_with_stat(stat) as entries:
+            entries = list(entries)
+        for entry in sorted(entries, key=lambda entry: entry.name):
+            current_path = self.from_path(entry.path)
+            if followlinks and entry.is_symlink():
+                entry = FileEntry(
+                    entry.name,
+                    entry.path,
+                    current_path.stat(follow_symlinks=True),
+                )
+            if entry.is_dir():
+                yield from current_path._scan_stat_with_stat(
+                    entry.stat, missing_ok=missing_ok, followlinks=followlinks
+                )
+            else:
+                yield entry
+
+    def scan(self, missing_ok: bool = True, followlinks: bool = False) -> Iterator[str]:
+        """Iteratively traverse only files in given directory"""
+        scan_stat_iter = self.scan_stat(missing_ok=missing_ok, followlinks=followlinks)
+        for file_entry in scan_stat_iter:
+            yield file_entry.path
+
+    def scan_stat(
+        self, missing_ok: bool = True, followlinks: bool = False
+    ) -> Iterator[FileEntry]:
+        """Iteratively traverse only files in given directory"""
+
+        def create_generator() -> Iterator[FileEntry]:
+            stat = self._stat_or_none(follow_symlinks=followlinks)
+            if stat is None:
+                return
+            if stat.is_symlink() and not followlinks:
+                stat = self._stat_or_none(follow_symlinks=True)
+                if stat is None:
+                    return
+            yield from self._scan_stat_with_stat(stat, missing_ok, followlinks)
+
+        return _create_missing_ok_generator(
+            create_generator(),
+            missing_ok=missing_ok,
+            error=FileNotFoundError(
+                "No match any file in: %r" % self.path_with_protocol
+            ),
+        )
+
+    def scandir(self) -> ContextIterator:
+        """Get all content of given file path"""
+        stat = self.stat(follow_symlinks=False)
+        return self._scandir_with_stat(stat, follow_root_symlink=True)
+
     def stat(self, follow_symlinks=True) -> StatResult:
         """Get StatResult of file on sftp2"""
         try:
@@ -779,7 +799,7 @@ class Sftp2Path(URIPath):
             return _make_stat(stat)
         except SFTPProtocolError as e:  # pytype: disable=mro-error
             raise FileNotFoundError(
-                f"No such file or directory: {self.path_with_protocol!r}"
+                "No such file or directory: %r" % self.path_with_protocol
             ) from e
 
     def lstat(self) -> StatResult:
@@ -788,41 +808,54 @@ class Sftp2Path(URIPath):
 
     def unlink(self, missing_ok: bool = False) -> None:
         """Remove the file on sftp2"""
-        if missing_ok and not self.exists():
-            return
+        stat = self._stat_or_none(follow_symlinks=False)
+        if stat is None:
+            if missing_ok:
+                return
+            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+        if stat.is_dir():
+            raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
         self._client.unlink(self._remote_path)
 
     def walk(
         self, followlinks: bool = False
     ) -> Iterator[Tuple[str, List[str], List[str]]]:
         """Generate the file names in a directory tree by walking the tree top-down"""
-        if not self.exists(followlinks=followlinks):
+        stat = self._stat_or_none(follow_symlinks=followlinks)
+        if stat is not None and stat.is_symlink() and not followlinks:
+            stat = self._stat_or_none(follow_symlinks=True)
+        if stat is None or stat.is_file():
             return
 
-        if self.is_file(followlinks=followlinks):
-            return
-
-        stack = [self._remote_path]
+        stack = [(self, stat)]
         while stack:
-            root = stack.pop()
+            root_path, root_stat = stack.pop()
             dirs, files = [], []
+            child_stats = {}
 
-            # Use scandir instead of readdir for consistency
-            root_path = self._generate_path_object(root)
-            with root_path.scandir() as entries:
+            with root_path._scandir_with_stat(root_stat) as entries:
                 for entry in entries:
+                    if followlinks and entry.is_symlink():
+                        current_path = root_path.joinpath(entry.name)
+                        entry = FileEntry(
+                            entry.name,
+                            entry.path,
+                            current_path.stat(follow_symlinks=True),
+                        )
                     if entry.is_dir():
                         dirs.append(entry.name)
+                        child_stats[entry.name] = entry.stat
                     elif entry.is_file():
                         files.append(entry.name)
 
             dirs = sorted(dirs)
             files = sorted(files)
 
-            yield self._generate_path_object(root).path_with_protocol, dirs, files
+            yield root_path.path_with_protocol, dirs, files
 
             stack.extend(
-                (os.path.join(root, directory) for directory in reversed(dirs))
+                (root_path.joinpath(directory), child_stats[directory])
+                for directory in reversed(dirs)
             )
 
     def resolve(self, strict=False) -> "Sftp2Path":
@@ -850,31 +883,32 @@ class Sftp2Path(URIPath):
         """Create a symbolic link pointing to src_path named dst_path"""
         dst_path = self.from_path(dst_path)
         if dst_path.exists(followlinks=False):
-            raise FileExistsError(f"File exists: '{dst_path.path_with_protocol}'")
+            raise FileExistsError("File exists: %r" % dst_path.path_with_protocol)
         return self._client.symlink(self._remote_path, dst_path._remote_path)
 
     def readlink(self) -> "Sftp2Path":
         """Return a Sftp2Path instance representing the path to which the
         symbolic link points"""
-        if not self.exists():
+        stat = self._stat_or_none(follow_symlinks=False)
+        if stat is None:
             raise FileNotFoundError(
-                f"No such file or directory: '{self.path_with_protocol}'"
+                "No such file or directory: %r" % self.path_with_protocol
             )
-        if not self.is_symlink():
-            raise OSError(f"Not a symlink: {self.path_with_protocol!r}")
+        if not stat.is_symlink():
+            raise OSError("Not a symlink: %r" % self.path_with_protocol)
         try:
             path = self._client.realpath(self._remote_path)
             if not path:
-                raise OSError(f"Not a symlink: {self.path_with_protocol!r}")
+                raise OSError("Not a symlink: %r" % self.path_with_protocol)
             if not path.startswith("/"):
                 return self.parent.joinpath(path)
             return self._generate_path_object(path)
         except FileNotFoundError:
             raise FileNotFoundError(
-                f"No such file or directory: '{self.path_with_protocol}'"
+                "No such file or directory: %r" % self.path_with_protocol
             )
         except Exception:
-            raise OSError(f"Not a symlink: {self.path_with_protocol!r}")
+            raise OSError("Not a symlink: %r" % self.path_with_protocol)
 
     def is_symlink(self) -> bool:
         """Test whether a path is a symbolic link"""
@@ -903,12 +937,18 @@ class Sftp2Path(URIPath):
         **kwargs,
     ) -> IO:
         """Open a file on the path"""
+        stat = self._stat_or_none(follow_symlinks=False)
+        if stat is not None and stat.is_symlink():
+            stat = self._stat_or_none(follow_symlinks=True)
         if "w" in mode or "x" in mode or "a" in mode:
-            if self.is_dir():
-                raise IsADirectoryError(f"Is a directory: {self.path_with_protocol!r}")
+            if stat is not None and stat.is_dir():
+                raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
             self.parent.mkdir(parents=True, exist_ok=True)
-        elif not self.exists():
-            raise FileNotFoundError(f"No such file: {self.path_with_protocol!r}")
+        else:
+            if stat is None:
+                raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+            if stat.is_dir():
+                raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         # Convert mode for ssh2-python
         ssh2_mode = 0
@@ -965,8 +1005,8 @@ class Sftp2Path(URIPath):
 
     def rmdir(self):
         """Remove this directory. The directory must be empty"""
-        if len(self.listdir()) > 0:
-            raise OSError(f"Directory not empty: '{self.path_with_protocol}'")
+        if len(self._client.listdir(self._remote_path)) > 0:
+            raise OSError("Directory not empty: %r" % self.path_with_protocol)
         return self._client.rmdir(self._remote_path)
 
     def copy(
@@ -978,26 +1018,30 @@ class Sftp2Path(URIPath):
     ):
         """Copy the file to the given destination path"""
         if followlinks and self.is_symlink():
-            return self.readlink().copy(dst_path=dst_path, callback=callback)
+            return self.readlink().copy(
+                dst_path=dst_path,
+                callback=callback,
+                overwrite=overwrite,
+            )
 
         if not self._is_same_protocol(dst_path):
-            raise OSError(f"Not a {self.protocol} path: {dst_path!r}")
+            raise OSError("Not a %s path: %r" % (self.protocol, dst_path))
         if str(dst_path).endswith("/"):
-            raise IsADirectoryError(f"Is a directory: {dst_path!r}")
+            raise IsADirectoryError("Is a directory: %r" % dst_path)
 
-        if self.is_dir():
-            raise IsADirectoryError(f"Is a directory: {self.path_with_protocol!r}")
+        src_stat = self.stat(follow_symlinks=followlinks)
+        if src_stat.is_dir():
+            raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if not overwrite and self.from_path(dst_path).exists():
             return
 
         self.from_path(os.path.dirname(fspath(dst_path))).makedirs(exist_ok=True)
         dst_path = self.from_path(dst_path)
-
         if self._is_same_backend(dst_path):
             if self._remote_path == dst_path._remote_path:
                 raise SameFileError(
-                    f"'{self.path}' and '{dst_path.path}' are the same file"
+                    "%r and %r are the same file" % (self.path, dst_path.path)
                 )
             # Same server - use server-side copy command for efficiency
             exec_result = self._exec_command(
@@ -1016,7 +1060,7 @@ class Sftp2Path(URIPath):
                 )
 
             if callback:
-                callback(self.stat(follow_symlinks=followlinks).size)
+                callback(src_stat.size)
 
         else:
             # Fallback to traditional SFTP copy (download then upload)
@@ -1024,7 +1068,8 @@ class Sftp2Path(URIPath):
                 with dst_path.open("wb") as fdst:
                     copyfileobj(fsrc, fdst, callback)
 
-        src_stat = self.stat()
+        if src_stat.is_symlink():
+            src_stat = self.stat()
         dst_path.utime(src_stat.st_atime, src_stat.st_mtime)
         dst_path.chmod(src_stat.st_mode)
 
@@ -1037,7 +1082,7 @@ class Sftp2Path(URIPath):
     ):
         """Copy file/directory on src_url to dst_url"""
         if not self._is_same_protocol(dst_path):
-            raise OSError(f"Not a {self.protocol} path: {dst_path!r}")
+            raise OSError("Not a %s path: %r" % (self.protocol, dst_path))
 
         for src_file_path, dst_file_path in _sftp2_scan_pairs(
             self.path_with_protocol, dst_path
@@ -1045,12 +1090,13 @@ class Sftp2Path(URIPath):
             dst_path = self.from_path(dst_file_path)
             src_path = self.from_path(src_file_path)
 
+            dst_stat = dst_path._stat_or_none(follow_symlinks=False)
             if force:
                 pass
-            elif not overwrite and dst_path.exists():
+            elif not overwrite and dst_stat is not None:
                 continue
-            elif dst_path.exists() and is_same_file(
-                src_path.stat(), dst_path.stat(), "copy"
+            elif dst_stat is not None and is_same_file(
+                src_path.stat(), dst_stat, "copy"
             ):
                 continue
 

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -9,7 +9,7 @@ import socket
 import subprocess  # nosec B404
 from functools import cached_property
 from logging import getLogger as get_logger
-from stat import S_ISDIR, S_ISLNK, S_ISREG
+from stat import S_ISDIR, S_ISLNK
 from typing import IO, BinaryIO, Callable, Iterator, List, Optional, Tuple, Type, Union
 from urllib.parse import urlsplit, urlunsplit
 
@@ -71,8 +71,8 @@ def get_private_key():
         private_key_path = os.getenv(SFTP_PRIVATE_KEY_PATH)
         if not os.path.exists(private_key_path):
             raise FileNotFoundError(
-                "Private key file not exist, "
-                f"path:{private_key_path}, env:'{SFTP_PRIVATE_KEY_PATH}'"
+                "Private key file not exist, path:%r, env:%r"
+                % (private_key_path, SFTP_PRIVATE_KEY_PATH)
             )
         return key_with_types[key_type].from_private_key_file(
             private_key_path, password=os.getenv(SFTP_PRIVATE_KEY_PASSWORD)
@@ -430,7 +430,7 @@ def sftp_concat(src_paths: List[PathLike], dst_path: PathLike) -> None:
     exec_result = dst_path_obj._exec_command(command)
     if exec_result.returncode != 0:
         _logger.error(exec_result.stderr)
-        raise OSError(f"Failed to concat {src_paths} to {dst_path}")
+        raise OSError("Failed to concat %r to %r" % (src_paths, dst_path))
 
 
 def sftp_copy(
@@ -477,9 +477,9 @@ def sftp_download(
     from megfile.fs_path import FSPath, is_fs
 
     if not is_fs(dst_url):
-        raise OSError(f"dst_url is not fs path: {dst_url}")
+        raise OSError("dst_url is not fs path: %r" % dst_url)
     if not is_sftp(src_url) and not isinstance(src_url, SftpPath):
-        raise OSError(f"src_url is not sftp path: {src_url}")
+        raise OSError("src_url is not sftp path: %r" % src_url)
 
     dst_path = FSPath(dst_url)
     if not overwrite and dst_path.exists():
@@ -536,9 +536,9 @@ def sftp_upload(
     from megfile.fs_path import FSPath, is_fs
 
     if not is_fs(src_url):
-        raise OSError(f"src_url is not fs path: {src_url}")
+        raise OSError("src_url is not fs path: %r" % src_url)
     if not is_sftp(dst_url) and not isinstance(dst_url, SftpPath):
-        raise OSError(f"dst_url is not sftp path: {dst_url}")
+        raise OSError("dst_url is not sftp path: %r" % dst_url)
 
     if followlinks and os.path.islink(src_url):
         src_url = os.readlink(src_url)
@@ -831,8 +831,7 @@ class SftpPath(URIPath):
         """
         try:
             stat = self.stat(follow_symlinks=followlinks)
-            if S_ISREG(stat.st_mode):
-                return True
+            return stat.is_file()
         except FileNotFoundError:
             pass
         return False
@@ -884,7 +883,7 @@ class SftpPath(URIPath):
         """
         if self.exists():
             if not exist_ok:
-                raise FileExistsError(f"File exists: '{self.path_with_protocol}'")
+                raise FileExistsError("File exists: %r" % self.path_with_protocol)
             return
 
         if parents:
@@ -942,6 +941,7 @@ class SftpPath(URIPath):
             else:
                 self.sync(dst_path, overwrite=overwrite)
                 self.remove(missing_ok=True)
+            return dst_path
         else:
             if self.is_dir():
                 for file_entry in self.scandir():
@@ -976,14 +976,73 @@ class SftpPath(URIPath):
         :param missing_ok: if False and target file/directory not exists,
             raise FileNotFoundError
         """
-        if missing_ok and not self.exists():
-            return
-        if self.is_dir():
-            for file_entry in self.scandir():
+        stat = self._stat_or_none(follow_symlinks=False)
+        if stat is None:
+            if missing_ok:
+                return
+            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+        if stat.is_dir():
+            for file_entry in self._scandir_with_stat(stat):
                 self.from_path(file_entry.path).remove(missing_ok=missing_ok)
             self._client.rmdir(self._real_path)
         else:
             self._client.unlink(self._real_path)
+
+    def _scandir_with_stat(
+        self, stat: StatResult, follow_root_symlink: bool = False
+    ) -> ContextIterator:
+        """
+        Get all content of a known existing path.
+        """
+        real_path = self._real_path
+        if stat.is_symlink():
+            if follow_root_symlink:
+                stat = self.stat(follow_symlinks=True)
+            else:
+                raise NotADirectoryError(
+                    "Not a directory: %r" % self.path_with_protocol
+                )
+        if not stat.is_dir():
+            raise NotADirectoryError("Not a directory: %r" % self.path_with_protocol)
+
+        def create_generator():
+            for name in self._client.listdir(real_path):
+                current_path = self.joinpath(name)
+                yield FileEntry(
+                    current_path.name,
+                    current_path.path_with_protocol,
+                    current_path.lstat(),
+                )
+
+        return ContextIterator(create_generator())
+
+    def _scan_stat_with_stat(
+        self, stat: StatResult, missing_ok: bool, followlinks: bool
+    ) -> Iterator[FileEntry]:
+        if stat.is_file():
+            yield FileEntry(
+                self.name,
+                self.path_with_protocol,
+                stat,
+            )
+            return
+
+        with self._scandir_with_stat(stat) as entries:
+            entries = list(entries)
+        for entry in sorted(entries, key=lambda entry: entry.name):
+            current_path = self.from_path(entry.path)
+            if followlinks and entry.is_symlink():
+                entry = FileEntry(
+                    entry.name,
+                    entry.path,
+                    current_path.stat(follow_symlinks=True),
+                )
+            if entry.is_dir():
+                yield from current_path._scan_stat_with_stat(
+                    entry.stat, missing_ok=missing_ok, followlinks=followlinks
+                )
+            else:
+                yield entry
 
     def scan(self, missing_ok: bool = True, followlinks: bool = False) -> Iterator[str]:
         """
@@ -1016,30 +1075,14 @@ class SftpPath(URIPath):
         """
 
         def create_generator() -> Iterator[FileEntry]:
-            try:
-                stat = self.stat(follow_symlinks=followlinks)
-            except FileNotFoundError:
+            stat = self._stat_or_none(follow_symlinks=followlinks)
+            if stat is None:
                 return
-            if S_ISREG(stat.st_mode):
-                yield FileEntry(
-                    self.name,
-                    self.path_with_protocol,
-                    self.stat(follow_symlinks=followlinks),
-                )
-                return
-
-            for name in self.listdir():
-                current_path = self.joinpath(name)
-                if current_path.is_dir():
-                    yield from current_path.scan_stat(
-                        missing_ok=missing_ok, followlinks=followlinks
-                    )
-                else:
-                    yield FileEntry(
-                        current_path.name,
-                        current_path.path_with_protocol,
-                        current_path.stat(follow_symlinks=followlinks),
-                    )
+            if stat.is_symlink() and not followlinks:
+                stat = self._stat_or_none(follow_symlinks=True)
+                if stat is None:
+                    return
+            yield from self._scan_stat_with_stat(stat, missing_ok, followlinks)
 
         return _create_missing_ok_generator(
             create_generator(),
@@ -1055,23 +1098,8 @@ class SftpPath(URIPath):
 
         :returns: An iterator contains all contents have prefix path
         """
-        real_path = self._real_path
         stat = self.stat(follow_symlinks=False)
-        if stat.is_symlink():
-            real_path = self.readlink()._real_path
-        elif not stat.is_dir():
-            raise NotADirectoryError(f"Not a directory: '{self.path_with_protocol}'")
-
-        def create_generator():
-            for name in self._client.listdir(real_path):
-                current_path = self.joinpath(name)
-                yield FileEntry(
-                    current_path.name,
-                    current_path.path_with_protocol,
-                    current_path.lstat(),
-                )
-
-        return ContextIterator(create_generator())
+        return self._scandir_with_stat(stat, follow_root_symlink=True)
 
     def stat(self, follow_symlinks=True) -> StatResult:
         """
@@ -1092,8 +1120,13 @@ class SftpPath(URIPath):
 
         :param missing_ok: if False and target file not exists, raise FileNotFoundError
         """
-        if missing_ok and not self.exists():
-            return
+        stat = self._stat_or_none(follow_symlinks=False)
+        if stat is None:
+            if missing_ok:
+                return
+            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+        if stat.is_dir():
+            raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
         self._client.unlink(self._real_path)
 
     def walk(
@@ -1122,31 +1155,40 @@ class SftpPath(URIPath):
         :param followlinks: False if regard symlink as file, else True
         :returns: A 3-tuple generator
         """
-        if not self.exists(followlinks=followlinks):
+        stat = self._stat_or_none(follow_symlinks=followlinks)
+        if stat is not None and stat.is_symlink() and not followlinks:
+            stat = self._stat_or_none(follow_symlinks=True)
+        if stat is None or stat.is_file():
             return
 
-        if self.is_file(followlinks=followlinks):
-            return
-
-        stack = [self._real_path]
+        stack = [(self, stat)]
         while stack:
-            root = stack.pop()
+            root_path, root_stat = stack.pop()
             dirs, files = [], []
-            filenames = self._client.listdir(root)
-            for name in filenames:
-                current_path = self._generate_path_object(root).joinpath(name)
-                if current_path.is_file(followlinks=followlinks):
-                    files.append(name)
-                elif current_path.is_dir(followlinks=followlinks):
-                    dirs.append(name)
+            child_stats = {}
+            with root_path._scandir_with_stat(root_stat) as entries:
+                for entry in entries:
+                    if followlinks and entry.is_symlink():
+                        current_path = root_path.joinpath(entry.name)
+                        entry = FileEntry(
+                            entry.name,
+                            entry.path,
+                            current_path.stat(follow_symlinks=True),
+                        )
+                    if entry.is_dir():
+                        dirs.append(entry.name)
+                        child_stats[entry.name] = entry.stat
+                    elif entry.is_file():
+                        files.append(entry.name)
 
             dirs = sorted(dirs)
             files = sorted(files)
 
-            yield self._generate_path_object(root).path_with_protocol, dirs, files
+            yield root_path.path_with_protocol, dirs, files
 
             stack.extend(
-                (os.path.join(root, directory) for directory in reversed(dirs))
+                (root_path.joinpath(directory), child_stats[directory])
+                for directory in reversed(dirs)
             )
 
     def resolve(self, strict=False) -> "SftpPath":
@@ -1191,7 +1233,7 @@ class SftpPath(URIPath):
         """
         dst_path = self.from_path(dst_path)
         if dst_path.exists(followlinks=False):
-            raise FileExistsError(f"File exists: '{dst_path.path_with_protocol}'")
+            raise FileExistsError("File exists: %r" % dst_path.path_with_protocol)
         return self._client.symlink(self._real_path, dst_path._real_path)
 
     def readlink(self) -> "SftpPath":
@@ -1200,10 +1242,10 @@ class SftpPath(URIPath):
         which the symbolic link points.
         """
         if not self.is_symlink():
-            raise OSError("Not a symlink: %s" % self.path_with_protocol)
+            raise OSError("Not a symlink: %r" % self.path_with_protocol)
         path = self._client.readlink(self._real_path)
         if not path:
-            raise OSError("Not a symlink: %s" % self.path_with_protocol)
+            raise OSError("Not a symlink: %r" % self.path_with_protocol)
         if not path.startswith("/"):
             return self.parent.joinpath(path)
         return self._generate_path_object(path)
@@ -1253,12 +1295,18 @@ class SftpPath(URIPath):
             decoding errors are to be handled—this cannot be used in binary mode.
         :returns: File-Like object
         """
+        stat = self._stat_or_none(follow_symlinks=False)
+        if stat is not None and stat.is_symlink():
+            stat = self._stat_or_none(follow_symlinks=True)
         if "w" in mode or "x" in mode or "a" in mode:
-            if self.is_dir():
+            if stat is not None and stat.is_dir():
                 raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
             self.parent.mkdir(parents=True, exist_ok=True)
-        elif not self.exists():
-            raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+        else:
+            if stat is None:
+                raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
+            if stat.is_dir():
+                raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if atomic and mode not in ("r", "rb"):
             fs_func = FSFuncForAtomic(
@@ -1307,8 +1355,8 @@ class SftpPath(URIPath):
         """
         Remove this directory. The directory must be empty.
         """
-        if len(self.listdir()) > 0:
-            raise OSError(f"Directory not empty: '{self.path_with_protocol}'")
+        if len(self._client.listdir(self._real_path)) > 0:
+            raise OSError("Directory not empty: %r" % self.path_with_protocol)
         return self._client.rmdir(self._real_path)
 
     def _exec_command(
@@ -1361,14 +1409,19 @@ class SftpPath(URIPath):
         :raises OSError: If there is an error copying the file.
         """
         if followlinks and self.is_symlink():
-            return self.readlink().copy(dst_path=dst_path, callback=callback)
+            return self.readlink().copy(
+                dst_path=dst_path,
+                callback=callback,
+                overwrite=overwrite,
+            )
 
         if not self._is_same_protocol(dst_path):
             raise OSError("Not a %s path: %r" % (self.protocol, dst_path))
         if str(dst_path).endswith("/"):
             raise IsADirectoryError("Is a directory: %r" % dst_path)
 
-        if self.is_dir():
+        src_stat = self.stat(follow_symlinks=followlinks)
+        if src_stat.is_dir():
             raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if not overwrite and self.from_path(dst_path).exists():
@@ -1379,7 +1432,7 @@ class SftpPath(URIPath):
         if self._is_same_backend(dst_path):
             if self._real_path == dst_path._real_path:
                 raise SameFileError(
-                    f"'{self.path}' and '{dst_path.path}' are the same file"
+                    "%r and %r are the same file" % (self.path, dst_path.path)
                 )
             exec_result = self._exec_command(
                 ["cp", self._real_path, dst_path._real_path]
@@ -1388,13 +1441,14 @@ class SftpPath(URIPath):
                 _logger.error(exec_result.stderr)
                 raise OSError(f"Copy file error, returncode: {exec_result.returncode}")
             if callback:
-                callback(self.stat(follow_symlinks=followlinks).size)
+                callback(src_stat.size)
         else:
             with self.open("rb") as fsrc:
                 with dst_path.open("wb") as fdst:
                     copyfileobj(fsrc, fdst, callback)
 
-        src_stat = self.stat()
+        if src_stat.is_symlink():
+            src_stat = self.stat()
         dst_path.utime(src_stat.st_atime, src_stat.st_mtime)
         dst_path.chmod(src_stat.st_mode)
 
@@ -1422,12 +1476,13 @@ class SftpPath(URIPath):
             dst_path = self.from_path(dst_file_path)
             src_path = self.from_path(src_file_path)
 
+            dst_stat = dst_path._stat_or_none(follow_symlinks=False)
             if force:
                 pass
-            elif not overwrite and dst_path.exists():
+            elif not overwrite and dst_stat is not None:
                 continue
-            elif dst_path.exists() and is_same_file(
-                src_path.stat(), dst_path.stat(), "copy"
+            elif dst_stat is not None and is_same_file(
+                src_path.stat(), dst_stat, "copy"
             ):
                 continue
 

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -19,6 +19,8 @@ class FakeSFTPClient:
     def __init__(self):
         self._retry_times = 0
         self.sock = None
+        self.stat_calls = []
+        self.lstat_calls = []
 
     def __enter__(self):
         return self
@@ -69,9 +71,11 @@ class FakeSFTPClient:
         os.rmdir(path)
 
     def stat(self, path):
+        self.stat_calls.append(path)
         return paramiko.SFTPAttributes.from_stat(os.stat(path))
 
     def lstat(self, path):
+        self.lstat_calls.append(path)
         return paramiko.SFTPAttributes.from_stat(os.lstat(path))
 
     def symlink(self, source, dest):
@@ -298,18 +302,35 @@ def test_sftp_glob(sftp_mocker):
     ]
     assert sftp.sftp_glob("sftp://username@host//A/") == ["sftp://username@host//A/"]
 
+    sftp.sftp_symlink("sftp://username@host//A", "sftp://username@host//A.link")
+    assert sftp.sftp_glob("sftp://username@host//A.link/*") == [
+        "sftp://username@host//A.link/1.json",
+        "sftp://username@host//A.link/a",
+        "sftp://username@host//A.link/b",
+    ]
+
 
 def test_sftp_isdir_sftp_isfile(sftp_mocker):
     sftp.sftp_makedirs("sftp://username@host//A/B", parents=True)
 
     with sftp.sftp_open("sftp://username@host//A/B/file", "w") as f:
         f.write("test")
+    sftp.sftp_symlink(
+        "sftp://username@host//A/B/file", "sftp://username@host//A/B/file.lnk"
+    )
+    sftp.sftp_symlink("sftp://username@host//A/B", "sftp://username@host//A/B.dir.lnk")
 
     assert sftp.sftp_isdir("sftp://username@host//A/B") is True
     assert sftp.sftp_isdir("sftp://username@host//A/B/file") is False
     assert sftp.sftp_isfile("sftp://username@host//A/B/file") is True
     assert sftp.sftp_isfile("sftp://username@host//A/B") is False
     assert sftp.sftp_isfile("sftp://username@host//A/C") is False
+    assert sftp.sftp_isfile("sftp://username@host//A/B/file.lnk") is True
+    assert sftp.sftp_isfile("sftp://username@host//A/B.dir.lnk") is True
+    assert sftp.sftp_isdir("sftp://username@host//A/B.dir.lnk") is False
+    assert (
+        sftp.sftp_isdir("sftp://username@host//A/B.dir.lnk", followlinks=True) is True
+    )
 
 
 def test_sftp_exists(sftp_mocker):
@@ -490,6 +511,47 @@ def test_sftp_rename(sftp_mocker):
         sftp.sftp_rename("sftp://username@host//A/test2", "/A/test")
 
 
+def test_sftp_rename_directory_symlink(sftp_mocker, mocker):
+    sftp.sftp_makedirs("sftp://username@host//A/dir", parents=True)
+    with sftp.sftp_open("sftp://username@host//A/dir/file", "w") as f:
+        f.write("test")
+    sftp.sftp_symlink("sftp://username@host//A/dir", "sftp://username@host//A/linkdir")
+
+    calls = []
+
+    def record_utime(path, atime, mtime):
+        calls.append(("utime", path.path_with_protocol, atime, mtime))
+
+    def record_chmod(path, mode, *, follow_symlinks=True):
+        calls.append(("chmod", path.path_with_protocol, mode, follow_symlinks))
+
+    mocker.patch.object(sftp_path.SftpPath, "utime", record_utime)
+    mocker.patch.object(sftp_path.SftpPath, "chmod", record_chmod)
+
+    sftp.sftp_rename(
+        "sftp://username@host//A/linkdir", "sftp://username@host//A/linkdir2"
+    )
+
+    assert sftp.sftp_exists("sftp://username@host//A/dir/file") is True
+    assert sftp.sftp_islink("sftp://username@host//A/linkdir2") is True
+    assert sftp.sftp_exists("sftp://username@host//A/linkdir") is False
+    assert calls == []
+
+
+def test_sftp_rename_symlink_cross_backend_materializes_target(sftp_mocker):
+    sftp.sftp_makedirs("sftp://username@host//A")
+    with sftp.sftp_open("sftp://username@host//A/file", "w") as f:
+        f.write("test")
+    sftp.sftp_symlink("sftp://username@host//A/file", "sftp://username@host//A/link")
+
+    sftp.sftp_rename("sftp://username@host//A/link", "sftp://username2@host2/B/link")
+
+    assert sftp.sftp_exists("sftp://username@host//A/link") is False
+    assert sftp.sftp_islink("sftp://username2@host2/B/link") is False
+    with sftp.sftp_open("sftp://username2@host2/B/link") as f:
+        assert f.read() == "test"
+
+
 def test_sftp_move(sftp_mocker):
     sftp.sftp_makedirs("sftp://username@host//A")
     with sftp.sftp_open("sftp://username@host//A/test", "w") as f:
@@ -549,6 +611,30 @@ def test_sftp_open(sftp_mocker):
     with pytest.raises(IsADirectoryError):
         with sftp.sftp_open("sftp://username@host//A", "w") as f:
             f.read()
+
+    sftp.sftp_symlink("sftp://username@host//A", "sftp://username@host//A.link")
+    with pytest.raises(IsADirectoryError):
+        with sftp.sftp_open("sftp://username@host//A.link", "r") as f:
+            f.read()
+    with pytest.raises(IsADirectoryError):
+        with sftp.sftp_open("sftp://username@host//A.link", "w") as f:
+            f.write("test")
+
+
+def test_sftp_open_read_uses_single_lstat(sftp_mocker):
+    sftp.sftp_makedirs("sftp://username@host//A")
+    with sftp.sftp_open("sftp://username@host//A/test", "w") as f:
+        f.write("test")
+
+    client = sftp_path.SftpPath("sftp://username@host//A/test")._client
+    client.stat_calls.clear()
+    client.lstat_calls.clear()
+
+    with sftp.sftp_open("sftp://username@host//A/test", "r") as f:
+        assert f.read() == "test"
+
+    assert client.stat_calls == []
+    assert client.lstat_calls == ["/A/test"]
 
 
 def test_sftp_remove(sftp_mocker):
@@ -616,6 +702,47 @@ def test_sftp_scan(sftp_mocker):
     with pytest.raises(FileNotFoundError):
         list(sftp.sftp_scan_stat("sftp://username@host//B", missing_ok=False))
 
+    sftp.sftp_symlink("sftp://username@host//A", "sftp://username@host//A.link")
+    assert list(sftp.sftp_scan("sftp://username@host//A.link")) == [
+        "sftp://username@host//A.link/1.json",
+        "sftp://username@host//A.link/1.json.lnk",
+        "sftp://username@host//A.link/b/file.json",
+    ]
+    assert list(sftp.sftp_scan("sftp://username@host//A.link", followlinks=True)) == [
+        "sftp://username@host//A.link/1.json",
+        "sftp://username@host//A.link/1.json.lnk",
+        "sftp://username@host//A.link/b/file.json",
+    ]
+
+
+def test_sftp_scan_stat_reuses_entry_stat(sftp_mocker):
+    sftp.sftp_makedirs("sftp://username@host//A/b", parents=True)
+    with sftp.sftp_open("sftp://username@host//A/1.json", "w") as f:
+        f.write("1.json")
+    with sftp.sftp_open("sftp://username@host//A/b/file.json", "w") as f:
+        f.write("file")
+
+    client = sftp_path.SftpPath("sftp://username@host//A")._client
+    client.stat_calls.clear()
+    client.lstat_calls.clear()
+
+    assert [
+        file_entry.path for file_entry in sftp.sftp_scan_stat("sftp://username@host//A")
+    ] == [
+        "sftp://username@host//A/1.json",
+        "sftp://username@host//A/b/file.json",
+    ]
+    assert client.stat_calls == []
+    assert sorted(client.lstat_calls) == sorted(
+        [
+            "/A",
+            "/A/b",
+            "/A/1.json",
+            "/A/b/file.json",
+        ]
+    )
+    assert client.lstat_calls.count("/A/b") == 1
+
 
 def test_sftp_unlink(sftp_mocker):
     sftp.sftp_makedirs("sftp://username@host//A")
@@ -656,6 +783,55 @@ def test_sftp_walk(sftp_mocker):
 
     assert list(sftp.sftp_walk("sftp://username@host//A/not_found")) == []
     assert list(sftp.sftp_walk("sftp://username@host//A/1.json")) == []
+
+    sftp.sftp_symlink("sftp://username@host//A", "sftp://username@host//A.link")
+    assert list(sftp.sftp_walk("sftp://username@host//A.link")) == [
+        ("sftp://username@host//A.link", ["a", "b"], ["1.json"]),
+        ("sftp://username@host//A.link/a", ["b"], ["2.json"]),
+        ("sftp://username@host//A.link/a/b", [], []),
+        ("sftp://username@host//A.link/b", ["c"], ["3.json"]),
+        ("sftp://username@host//A.link/b/c", [], []),
+    ]
+    assert list(sftp.sftp_walk("sftp://username@host//A.link", followlinks=True)) == [
+        ("sftp://username@host//A.link", ["a", "b"], ["1.json"]),
+        ("sftp://username@host//A.link/a", ["b"], ["2.json"]),
+        ("sftp://username@host//A.link/a/b", [], []),
+        ("sftp://username@host//A.link/b", ["c"], ["3.json"]),
+        ("sftp://username@host//A.link/b/c", [], []),
+    ]
+
+
+def test_sftp_walk_reuses_entry_stat(sftp_mocker):
+    sftp.sftp_makedirs("sftp://username@host//A/a", parents=True)
+    sftp.sftp_makedirs("sftp://username@host//A/b/c", parents=True)
+    with sftp.sftp_open("sftp://username@host//A/1.json", "w") as f:
+        f.write("1.json")
+    with sftp.sftp_open("sftp://username@host//A/b/3.json", "w") as f:
+        f.write("3.json")
+
+    client = sftp_path.SftpPath("sftp://username@host//A")._client
+    client.stat_calls.clear()
+    client.lstat_calls.clear()
+
+    assert list(sftp.sftp_walk("sftp://username@host//A")) == [
+        ("sftp://username@host//A", ["a", "b"], ["1.json"]),
+        ("sftp://username@host//A/a", [], []),
+        ("sftp://username@host//A/b", ["c"], ["3.json"]),
+        ("sftp://username@host//A/b/c", [], []),
+    ]
+    assert client.stat_calls == []
+    assert sorted(client.lstat_calls) == sorted(
+        [
+            "/A",
+            "/A/a",
+            "/A/b",
+            "/A/1.json",
+            "/A/b/c",
+            "/A/b/3.json",
+        ]
+    )
+    assert client.lstat_calls.count("/A/b") == 1
+    assert client.lstat_calls.count("/A/b/c") == 1
 
 
 def test_sftp_getmd5(sftp_mocker):
@@ -702,14 +878,24 @@ def test_sftp_rmdir(sftp_mocker):
     with sftp.sftp_open("sftp://username@host//A/1.json", "w") as f:
         f.write("1.json")
 
+    client = sftp_path.SftpPath("sftp://username@host//A")._client
+    client.stat_calls.clear()
+    client.lstat_calls.clear()
+
     with pytest.raises(OSError):
         sftp.sftp_rmdir("sftp://username@host//A")
+    assert client.stat_calls == []
+    assert client.lstat_calls == []
 
     with pytest.raises(NotADirectoryError):
         sftp.sftp_rmdir("sftp://username@host//A/1.json")
 
     sftp.sftp_unlink("sftp://username@host//A/1.json")
+    client.stat_calls.clear()
+    client.lstat_calls.clear()
     sftp.sftp_rmdir("sftp://username@host//A")
+    assert client.stat_calls == []
+    assert client.lstat_calls == []
     assert sftp.sftp_exists("sftp://username@host//A") is False
 
 
@@ -735,6 +921,42 @@ def test_sftp_copy(sftp_mocker):
         sftp.sftp_stat("sftp://username@host//A/1.json").size
         == sftp.sftp_stat("sftp://username@host//A2/1.json.bak").size
     )
+    with sftp.sftp_open("sftp://username@host//A2/overwrite_false.json", "w") as f:
+        f.write("old")
+    sftp.sftp_copy(
+        "sftp://username@host//A/1.json.lnk",
+        "sftp://username@host//A2/overwrite_false.json",
+        followlinks=True,
+        overwrite=False,
+    )
+    assert sftp.sftp_stat("sftp://username@host//A2/overwrite_false.json").size == len(
+        "old"
+    )
+
+    sftp.sftp_copy(
+        "sftp://username@host//A/1.json.lnk",
+        "sftp://username@host//A2/1.json.lnk",
+    )
+    assert sftp.sftp_islink("sftp://username@host//A2/1.json.lnk") is False
+    assert (
+        sftp.sftp_stat("sftp://username@host//A/1.json").size
+        == sftp.sftp_stat("sftp://username@host//A2/1.json.lnk").size
+    )
+
+    client = sftp_path.SftpPath("sftp://username@host//A/1.json")._client
+    client.stat_calls.clear()
+    client.lstat_calls.clear()
+    sftp.sftp_copy(
+        "sftp://username@host//A/1.json",
+        "sftp://username@host//A2/1.json.copy",
+        callback=callback,
+    )
+    assert "/A/1.json" not in client.stat_calls
+    assert client.lstat_calls.count("/A/1.json") == 1
+
+    sftp.sftp_symlink("sftp://username@host//A", "sftp://username@host//A.link")
+    with pytest.raises(IsADirectoryError):
+        sftp.sftp_copy("sftp://username@host//A.link", "sftp://username@host//A2/dir")
 
     with sftp.sftp_open("sftp://username@host//A/2.json", "w") as f:
         f.write("2")
@@ -903,6 +1125,10 @@ def test_sftp_download(sftp_mocker):
         == os.stat("/A2/2.json").st_size
     )
 
+    sftp.sftp_download("sftp://username@host//A/1.json.lnk", "/A2/1.json.lnk")
+    assert os.path.islink("/A2/1.json.lnk") is False
+    assert os.stat("/A2/1.json.lnk").st_size == os.stat("/A/1.json").st_size
+
     with pytest.raises(OSError):
         sftp.sftp_download(
             "sftp://username@host//A/1.json", "sftp://username@host//1.json"
@@ -913,6 +1139,10 @@ def test_sftp_download(sftp_mocker):
 
     with pytest.raises(IsADirectoryError):
         sftp.sftp_download("sftp://username@host//A", "/1.json")
+
+    sftp.sftp_symlink("sftp://username@host//A", "sftp://username@host//A.link")
+    with pytest.raises(IsADirectoryError):
+        sftp.sftp_download("sftp://username@host//A.link", "/1.json")
 
     with pytest.raises(IsADirectoryError):
         sftp.sftp_download("sftp://username@host//A/1.json", "/1/")

--- a/tests/test_sftp2.py
+++ b/tests/test_sftp2.py
@@ -7,12 +7,15 @@ from typing import List
 
 import pytest
 
+from megfile.sftp2_path import Sftp2Path
 from tests.compat import sftp2
 
 
 class FakeSFTP2Client:
     def __init__(self):
         self._retry_times = 0
+        self.stat_calls = []
+        self.lstat_calls = []
 
     def __enter__(self):
         return self
@@ -49,9 +52,11 @@ class FakeSFTP2Client:
         os.rmdir(path)
 
     def stat(self, path):
+        self.stat_calls.append(path)
         return FakeSFTP2Stat(os.stat(path))
 
     def lstat(self, path):
+        self.lstat_calls.append(path)
         return FakeSFTP2Stat(os.lstat(path))
 
     def symlink(self, source, dest):
@@ -275,6 +280,22 @@ def test_sftp2_readlink(sftp2_mocker):
         sftp2.sftp2_readlink("sftp2://username@host/file")
 
 
+def test_sftp2_readlink_uses_single_lstat(sftp2_mocker):
+    path = "sftp2://username@host/file"
+    link_path = "sftp2://username@host/file.lnk"
+
+    with sftp2.sftp2_open(path, "w") as f:
+        f.write("test")
+    sftp2.sftp2_symlink(path, link_path)
+
+    sftp2_mocker.stat_calls.clear()
+    sftp2_mocker.lstat_calls.clear()
+
+    assert sftp2.sftp2_readlink(link_path) == path
+    assert sftp2_mocker.stat_calls == []
+    assert sftp2_mocker.lstat_calls == ["/file.lnk"]
+
+
 def test_sftp2_absolute(sftp2_mocker):
     assert (
         sftp2.sftp2_absolute("sftp2://username@host/dir/../file").path_with_protocol
@@ -322,6 +343,12 @@ def test_sftp2_glob(sftp2_mocker):
         "sftp2://username@host/A/a",
         "sftp2://username@host/A/b",
     ]
+    sftp2.sftp2_symlink("sftp2://username@host/A", "sftp2://username@host/A.link")
+    assert sftp2.sftp2_glob("sftp2://username@host/A.link/*") == [
+        "sftp2://username@host/A.link/1.json",
+        "sftp2://username@host/A.link/a",
+        "sftp2://username@host/A.link/b",
+    ]
 
 
 def test_sftp2_isdir_sftp2_isfile(sftp2_mocker):
@@ -329,12 +356,22 @@ def test_sftp2_isdir_sftp2_isfile(sftp2_mocker):
 
     with sftp2.sftp2_open("sftp2://username@host/A/B/file", "w") as f:
         f.write("test")
+    sftp2.sftp2_symlink(
+        "sftp2://username@host/A/B/file", "sftp2://username@host/A/B/file.lnk"
+    )
+    sftp2.sftp2_symlink(
+        "sftp2://username@host/A/B", "sftp2://username@host/A/B.dir.lnk"
+    )
 
     assert sftp2.sftp2_isdir("sftp2://username@host/A/B") is True
     assert sftp2.sftp2_isdir("sftp2://username@host/A/B/file") is False
     assert sftp2.sftp2_isfile("sftp2://username@host/A/B/file") is True
     assert sftp2.sftp2_isfile("sftp2://username@host/A/B") is False
     assert sftp2.sftp2_isfile("sftp2://username@host/A/C") is False
+    assert sftp2.sftp2_isfile("sftp2://username@host/A/B/file.lnk") is True
+    assert sftp2.sftp2_isfile("sftp2://username@host/A/B.dir.lnk") is True
+    assert sftp2.sftp2_isdir("sftp2://username@host/A/B.dir.lnk") is False
+    assert sftp2.sftp2_isdir("sftp2://username@host/A/B.dir.lnk", followlinks=True)
 
 
 def test_sftp2_exists(sftp2_mocker):
@@ -376,6 +413,18 @@ def test_sftp2_scandir(sftp2_mocker):
         "sftp2://username@host/A/1.json",
         "sftp2://username@host/A/a",
         "sftp2://username@host/A/b",
+    ]
+
+    sftp2.sftp2_symlink("sftp2://username@host/A", "sftp2://username@host/A.link")
+    assert sorted(
+        [
+            file_entry.path
+            for file_entry in sftp2.sftp2_scandir("sftp2://username@host/A.link")
+        ]
+    ) == [
+        "sftp2://username@host/A.link/1.json",
+        "sftp2://username@host/A.link/a",
+        "sftp2://username@host/A.link/b",
     ]
 
 
@@ -459,6 +508,49 @@ def test_sftp2_rename(sftp2_mocker):
     assert sftp2.sftp2_exists("sftp2://username@host/A/test2") is True
 
 
+def test_sftp2_rename_directory_symlink(sftp2_mocker, mocker):
+    sftp2.sftp2_makedirs("sftp2://username@host/A/dir", parents=True)
+    with sftp2.sftp2_open("sftp2://username@host/A/dir/file", "w") as f:
+        f.write("test")
+    sftp2.sftp2_symlink(
+        "sftp2://username@host/A/dir", "sftp2://username@host/A/linkdir"
+    )
+
+    calls = []
+
+    def record_utime(path, atime, mtime):
+        calls.append(("utime", path.path_with_protocol, atime, mtime))
+
+    def record_chmod(path, mode, *, follow_symlinks=True):
+        calls.append(("chmod", path.path_with_protocol, mode, follow_symlinks))
+
+    mocker.patch.object(Sftp2Path, "utime", record_utime)
+    mocker.patch.object(Sftp2Path, "chmod", record_chmod)
+
+    sftp2.sftp2_rename(
+        "sftp2://username@host/A/linkdir", "sftp2://username@host/A/linkdir2"
+    )
+
+    assert sftp2.sftp2_exists("sftp2://username@host/A/dir/file") is True
+    assert sftp2.sftp2_islink("sftp2://username@host/A/linkdir2") is True
+    assert sftp2.sftp2_exists("sftp2://username@host/A/linkdir") is False
+    assert calls == []
+
+
+def test_sftp2_rename_symlink_cross_backend_materializes_target(sftp2_mocker):
+    sftp2.sftp2_makedirs("sftp2://username@host/A")
+    with sftp2.sftp2_open("sftp2://username@host/A/file", "w") as f:
+        f.write("test")
+    sftp2.sftp2_symlink("sftp2://username@host/A/file", "sftp2://username@host/A/link")
+
+    sftp2.sftp2_rename("sftp2://username@host/A/link", "sftp2://username2@host2/B/link")
+
+    assert sftp2.sftp2_exists("sftp2://username@host/A/link") is False
+    assert sftp2.sftp2_islink("sftp2://username2@host2/B/link") is False
+    with sftp2.sftp2_open("sftp2://username2@host2/B/link") as f:
+        assert f.read() == "test"
+
+
 def test_sftp2_move(sftp2_mocker):
     sftp2.sftp2_makedirs("sftp2://username@host/A")
     with sftp2.sftp2_open("sftp2://username@host/A/test", "w") as f:
@@ -489,6 +581,29 @@ def test_sftp2_open(sftp2_mocker):
     with pytest.raises(IsADirectoryError):
         with sftp2.sftp2_open("sftp2://username@host/A", "w") as f:
             f.read()
+
+    sftp2.sftp2_symlink("sftp2://username@host/A", "sftp2://username@host/A.link")
+    with pytest.raises(IsADirectoryError):
+        with sftp2.sftp2_open("sftp2://username@host/A.link", "r") as f:
+            f.read()
+    with pytest.raises(IsADirectoryError):
+        with sftp2.sftp2_open("sftp2://username@host/A.link", "w") as f:
+            f.write("test")
+
+
+def test_sftp2_open_read_uses_single_lstat(sftp2_mocker):
+    sftp2.sftp2_makedirs("sftp2://username@host/A")
+    with sftp2.sftp2_open("sftp2://username@host/A/test", "w") as f:
+        f.write("test")
+
+    sftp2_mocker.stat_calls.clear()
+    sftp2_mocker.lstat_calls.clear()
+
+    with sftp2.sftp2_open("sftp2://username@host/A/test", "r") as f:
+        assert f.read() == "test"
+
+    assert sftp2_mocker.stat_calls == []
+    assert sftp2_mocker.lstat_calls == ["/A/test"]
 
 
 def test_sftp2_remove(sftp2_mocker):
@@ -528,6 +643,39 @@ def test_sftp2_scan(sftp2_mocker):
         "sftp2://username@host/A/b/file.json",
     ]
 
+    sftp2.sftp2_symlink("sftp2://username@host/A", "sftp2://username@host/A.link")
+    assert list(sftp2.sftp2_scan("sftp2://username@host/A.link")) == [
+        "sftp2://username@host/A.link/1.json",
+        "sftp2://username@host/A.link/1.json.lnk",
+        "sftp2://username@host/A.link/b/file.json",
+    ]
+    assert list(sftp2.sftp2_scan("sftp2://username@host/A.link", followlinks=True)) == [
+        "sftp2://username@host/A.link/1.json",
+        "sftp2://username@host/A.link/1.json.lnk",
+        "sftp2://username@host/A.link/b/file.json",
+    ]
+
+
+def test_sftp2_scan_stat_reuses_entry_stat(sftp2_mocker):
+    sftp2.sftp2_makedirs("sftp2://username@host/A/b", parents=True)
+    with sftp2.sftp2_open("sftp2://username@host/A/1.json", "w") as f:
+        f.write("1.json")
+    with sftp2.sftp2_open("sftp2://username@host/A/b/file.json", "w") as f:
+        f.write("file")
+
+    sftp2_mocker.stat_calls.clear()
+    sftp2_mocker.lstat_calls.clear()
+
+    assert [
+        file_entry.path
+        for file_entry in sftp2.sftp2_scan_stat("sftp2://username@host/A")
+    ] == [
+        "sftp2://username@host/A/1.json",
+        "sftp2://username@host/A/b/file.json",
+    ]
+    assert sftp2_mocker.stat_calls == []
+    assert sftp2_mocker.lstat_calls == ["/A"]
+
 
 def test_sftp2_unlink(sftp2_mocker):
     sftp2.sftp2_makedirs("sftp2://username@host/A")
@@ -561,6 +709,43 @@ def test_sftp2_walk(sftp2_mocker):
         ("sftp2://username@host/A/b", ["c"], ["3.json"]),
         ("sftp2://username@host/A/b/c", [], []),
     ]
+
+    sftp2.sftp2_symlink("sftp2://username@host/A", "sftp2://username@host/A.link")
+    assert list(sftp2.sftp2_walk("sftp2://username@host/A.link")) == [
+        ("sftp2://username@host/A.link", ["a", "b"], ["1.json"]),
+        ("sftp2://username@host/A.link/a", ["b"], ["2.json"]),
+        ("sftp2://username@host/A.link/a/b", [], []),
+        ("sftp2://username@host/A.link/b", ["c"], ["3.json"]),
+        ("sftp2://username@host/A.link/b/c", [], []),
+    ]
+    assert list(sftp2.sftp2_walk("sftp2://username@host/A.link", followlinks=True)) == [
+        ("sftp2://username@host/A.link", ["a", "b"], ["1.json"]),
+        ("sftp2://username@host/A.link/a", ["b"], ["2.json"]),
+        ("sftp2://username@host/A.link/a/b", [], []),
+        ("sftp2://username@host/A.link/b", ["c"], ["3.json"]),
+        ("sftp2://username@host/A.link/b/c", [], []),
+    ]
+
+
+def test_sftp2_walk_reuses_entry_stat(sftp2_mocker):
+    sftp2.sftp2_makedirs("sftp2://username@host/A/a", parents=True)
+    sftp2.sftp2_makedirs("sftp2://username@host/A/b/c", parents=True)
+    with sftp2.sftp2_open("sftp2://username@host/A/1.json", "w") as f:
+        f.write("1.json")
+    with sftp2.sftp2_open("sftp2://username@host/A/b/3.json", "w") as f:
+        f.write("3.json")
+
+    sftp2_mocker.stat_calls.clear()
+    sftp2_mocker.lstat_calls.clear()
+
+    assert list(sftp2.sftp2_walk("sftp2://username@host/A")) == [
+        ("sftp2://username@host/A", ["a", "b"], ["1.json"]),
+        ("sftp2://username@host/A/a", [], []),
+        ("sftp2://username@host/A/b", ["c"], ["3.json"]),
+        ("sftp2://username@host/A/b/c", [], []),
+    ]
+    assert sftp2_mocker.stat_calls == []
+    assert sftp2_mocker.lstat_calls == ["/A"]
 
 
 def test_sftp2_getmd5(sftp2_mocker):
@@ -609,11 +794,20 @@ def test_sftp2_rmdir(sftp2_mocker):
     with sftp2.sftp2_open("sftp2://username@host/A/1.json", "w") as f:
         f.write("1.json")
 
+    sftp2_mocker.stat_calls.clear()
+    sftp2_mocker.lstat_calls.clear()
+
     with pytest.raises(OSError):
         sftp2.sftp2_rmdir("sftp2://username@host/A")
+    assert sftp2_mocker.stat_calls == []
+    assert sftp2_mocker.lstat_calls == []
 
     sftp2.sftp2_unlink("sftp2://username@host/A/1.json")
+    sftp2_mocker.stat_calls.clear()
+    sftp2_mocker.lstat_calls.clear()
     sftp2.sftp2_rmdir("sftp2://username@host/A")
+    assert sftp2_mocker.stat_calls == []
+    assert sftp2_mocker.lstat_calls == []
     assert sftp2.sftp2_exists("sftp2://username@host/A") is False
 
 
@@ -639,6 +833,41 @@ def test_sftp2_copy(sftp2_mocker):
         sftp2.sftp2_stat("sftp2://username@host/A/1.json").size
         == sftp2.sftp2_stat("sftp2://username@host/A2/1.json.bak").size
     )
+    with sftp2.sftp2_open("sftp2://username@host/A2/overwrite_false.json", "w") as f:
+        f.write("old")
+    sftp2.sftp2_copy(
+        "sftp2://username@host/A/1.json.lnk",
+        "sftp2://username@host/A2/overwrite_false.json",
+        followlinks=True,
+        overwrite=False,
+    )
+    assert sftp2.sftp2_stat(
+        "sftp2://username@host/A2/overwrite_false.json"
+    ).size == len("old")
+
+    sftp2.sftp2_copy(
+        "sftp2://username@host/A/1.json.lnk",
+        "sftp2://username@host/A2/1.json.lnk",
+    )
+    assert sftp2.sftp2_islink("sftp2://username@host/A2/1.json.lnk") is False
+    assert (
+        sftp2.sftp2_stat("sftp2://username@host/A/1.json").size
+        == sftp2.sftp2_stat("sftp2://username@host/A2/1.json.lnk").size
+    )
+
+    sftp2_mocker.stat_calls.clear()
+    sftp2_mocker.lstat_calls.clear()
+    sftp2.sftp2_copy(
+        "sftp2://username@host/A/1.json",
+        "sftp2://username@host/A2/1.json.copy",
+        callback=callback,
+    )
+    assert "/A/1.json" not in sftp2_mocker.stat_calls
+    assert sftp2_mocker.lstat_calls.count("/A/1.json") == 1
+
+    sftp2.sftp2_symlink("sftp2://username@host/A", "sftp2://username@host/A.link")
+    with pytest.raises(IsADirectoryError):
+        sftp2.sftp2_copy("sftp2://username@host/A.link", "sftp2://username@host/A2/dir")
 
 
 def test_sftp2_concat(sftp2_mocker):


### PR DESCRIPTION
## Summary

Reduce redundant stat/lstat calls in SFTP and SFTP2 paths by reusing `StatResult` objects that were already fetched. This follows the WebDAV stat-reuse cleanup.

## Stat Reuse / Request Count Changes

- Reuse known root and entry stats in `scan_stat()` and `walk()` instead of re-statting child directories.
- Use one lstat-style source classification for `remove()` and `unlink()` paths that need to distinguish missing/file/dir/symlink.
- Avoid child stat calls in `rmdir()` emptiness checks by listing the raw remote path directly.
- Reuse source stats in `copy()` for normal-file callback/metadata paths and collapse duplicate destination checks in `sync()`.
- Collapse `sftp2.readlink()` missing/symlink checks into one lstat.
- Add request-count regression coverage for SFTP and SFTP2.

## Behavior Adjustments In This PR

- `SftpPath.is_file(..., followlinks=False)` and `Sftp2Path.is_file(..., followlinks=False)` now treat symlinks as files, matching the existing megfile local `StatResult.is_file()` convention.
- `SftpPath.open()` and `Sftp2Path.open()` still use one lstat for normal files, but when that lstat finds a symlink they stat the target before opening. This makes `open(link_to_dir)` raise `IsADirectoryError` instead of letting the backend open path handle it inconsistently.
- `copy(followlinks=True, overwrite=False)` now preserves `overwrite`. Previously the `readlink().copy(...)` shortcut dropped `overwrite` and could overwrite an existing destination.
- Same-backend `rename()` returns immediately after native rename and no longer performs extra `utime/chmod` writes. Native rename already preserves metadata; the old writes were extra side effects and ambiguous for symlinks.
- `unlink()` now classifies with lstat and raises `IsADirectoryError` for directories before calling remote unlink. This matches the file-only API intent and avoids relying on backend-specific unlink errors.

## Cleanup In This PR

- Normalize SFTP/SFTP2 path-bearing error messages to use `%r`, matching the WebDAV cleanup. Non-path diagnostic errors such as seek mode and return code messages are left unchanged.

## Behavior Intentionally Preserved

- Cross-backend `rename()` keeps the previous symlink behavior: a symlink source is copied through the generic open/copy path and generally materializes the target content, then removes the source link.
- `copy(..., followlinks=False)` keeps the previous SFTP/SFTP2 behavior: a symlink source is copied through the backend copy/open path, so it generally materializes the target content rather than preserving the symlink object.
- `download(..., followlinks=False)` keeps the previous SFTP behavior: downloading a symlink uses backend file read/get behavior and materializes the target content instead of creating a local symlink.
- Recursive `copy()` / `sync()` still use the existing scan/leaf-copy structure; this PR does not redefine which non-root symlink entries are copied.

## Still Surprising / Needs Discussion

These SFTP/SFTP2 behaviors remain unchanged because changing them would alter default behavior or which objects recursive operations copy:

- `copy()` / `sync()` symlink behavior differs from stdlib `copytree()` knobs: default leaf copy tends to materialize symlink targets, while recursive traversal treats symlink-to-dir entries as file entries unless traversal explicitly follows links.
- `sync(followlinks=True)` currently passes `followlinks` to each leaf `copy()`, but `_sftp_scan_pairs()` / `_sftp2_scan_pairs()` still scan with the default traversal behavior. Fixing that would change the recursive copy set, so this PR leaves it for separate discussion.
- `upload()` / `download()` symlink defaults are not fully symmetric with each other or with a hypothetical “preserve link object” copy mode.
- Cross-backend `rename()` on symlinks still materializes target content by default. This is surprising, but changing it would be a default-behavior change and should be handled separately.
- `md5(followlinks=...)` does not consistently honor the followlinks flag for directory-vs-symlink decisions. A narrow non-default `followlinks=True` fix may be safe, but changing default symlink handling would be a behavior change.

## Testing

- `pytest tests/test_sftp.py tests/test_sftp2.py -q`
- `make style_check`
- `make static_check` was run before the final small follow-up edits and passed; I did not rerun it after the last amend per review preference to avoid waiting on pytype.
