### PR TITLE
refactor: drop overwrite from move APIs

### DIFF
--- a/megfile/cli.py
+++ b/megfile/cli.py
@@ -364,14 +364,12 @@ def cp(
     "-T", "--no-target-directory", is_flag=True, help="treat dst_path as a normal file."
 )
 @click.option("-g", "--progress-bar", is_flag=True, help="Show progress bar.")
-@click.option("--skip", is_flag=True, help="Skip existed files.")
 def mv(
     src_path: str,
     dst_path: str,
     recursive: bool,
     no_target_directory: bool,
     progress_bar: bool,
-    skip: bool,
 ):
     if not no_target_directory and (dst_path.endswith("/") or smart_isdir(dst_path)):
         dst_path = smart_path_join(dst_path, os.path.basename(src_path))
@@ -386,21 +384,15 @@ def mv(
         if recursive:
             if src_protocol == dst_protocol:
                 with tqdm(total=1) as t:
-                    SmartPath(src_path).rename(
-                        dst_path, overwrite=not skip, recursive=True
-                    )
+                    SmartPath(src_path).rename(dst_path, recursive=True)
                     t.update(1)
             else:
-                smart_sync_with_progress(
-                    src_path, dst_path, followlinks=True, overwrite=not skip
-                )
+                smart_sync_with_progress(src_path, dst_path, followlinks=True)
                 smart_remove(src_path)
         else:
             if src_protocol == dst_protocol:
                 with tqdm(total=1) as t:
-                    SmartPath(src_path).rename(
-                        dst_path, overwrite=not skip, recursive=False
-                    )
+                    SmartPath(src_path).rename(dst_path, recursive=False)
                     t.update(1)
             else:
                 file_size = smart_stat(src_path).size
@@ -415,12 +407,12 @@ def mv(
                 def callback(length: int):
                     sbar.update(length)
 
-                smart_copy(src_path, dst_path, callback=callback, overwrite=not skip)
+                smart_copy(src_path, dst_path, callback=callback)
                 smart_unlink(src_path)
                 sbar.close()
     else:
         move_func = smart_move if recursive else smart_rename
-        move_func(src_path, dst_path, overwrite=not skip)
+        move_func(src_path, dst_path)
 
 
 @cli.command(short_help="Remove files from path.")

--- a/megfile/fs_path.py
+++ b/megfile/fs_path.py
@@ -96,20 +96,14 @@ def fs_copy(
     )
 
 
-def _fs_rename_file(
-    src_path: PathLike, dst_path: PathLike, overwrite: bool = True
-) -> None:
+def _fs_rename_file(src_path: PathLike, dst_path: PathLike) -> None:
     """
     rename file on fs
 
     :param src_path: Given path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     """
     src_path, dst_path = fspath(src_path), fspath(dst_path)
-
-    if not overwrite and os.path.exists(dst_path):
-        return
 
     dst_dir = os.path.dirname(dst_path)
     if dst_dir and dst_dir != ".":
@@ -491,23 +485,18 @@ class FSPath(URIPath):
             )
         )
 
-    def rename(
-        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
-    ) -> "FSPath":
+    def rename(self, dst_path: PathLike, recursive: bool = True) -> "FSPath":
         """
         rename file on fs
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         :param recursive: whether or not rename directory recursively
         """
         self._check_int_path()
 
         src_path, dst_path = fspath(self.path_without_protocol), fspath(dst_path)
         if os.path.isfile(src_path):
-            _fs_rename_file(src_path, dst_path, overwrite=overwrite)
-            if os.path.exists(src_path):
-                os.remove(src_path)
+            _fs_rename_file(src_path, dst_path)
             return self.from_path(dst_path)
         if not os.path.exists(src_path):
             raise FileNotFoundError("No such file: %r" % self.path_with_protocol)
@@ -526,24 +515,22 @@ class FSPath(URIPath):
                 if os.path.exists(dst_file_path) and file_entry.is_dir():
                     self.from_path(src_file_path).rename(
                         dst_file_path,
-                        overwrite=overwrite,
                         recursive=recursive,
                     )
                 else:
-                    _fs_rename_file(src_file_path, dst_file_path, overwrite=overwrite)
+                    _fs_rename_file(src_file_path, dst_file_path)
 
             shutil.rmtree(src_path, ignore_errors=True)
 
         return self.from_path(dst_path)
 
-    def replace(self, dst_path: PathLike, overwrite: bool = True) -> "FSPath":
+    def replace(self, dst_path: PathLike) -> "FSPath":
         """
         move file on fs
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         """
-        return self.rename(dst_path=dst_path, overwrite=overwrite)
+        return self.rename(dst_path=dst_path)
 
     def remove(self, missing_ok: bool = False) -> None:
         """

--- a/megfile/hdfs_path.py
+++ b/megfile/hdfs_path.py
@@ -12,7 +12,7 @@ from megfile.config import (
     READER_BLOCK_SIZE,
     READER_MAX_BUFFER_SIZE,
 )
-from megfile.errors import _create_missing_ok_generator, raise_hdfs_error
+from megfile.errors import SameFileError, _create_missing_ok_generator, raise_hdfs_error
 from megfile.interfaces import ContextIterator, FileEntry, PathLike, StatResult, URIPath
 from megfile.lib.compat import fspath
 from megfile.lib.glob import FSFunc, iglob
@@ -375,17 +375,21 @@ class HdfsPath(URIPath):
         with raise_hdfs_error(self.path_with_protocol):
             self._client.makedirs(self.path_without_protocol, permission=mode)
 
-    def rename(
-        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
-    ) -> "HdfsPath":
+    def rename(self, dst_path: PathLike, recursive: bool = True) -> "HdfsPath":
         """
         Move hdfs file path from src_path to dst_path
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         :param recursive: whether or not rename directory recursively
         """
         dst_path = self.from_path(dst_path)
+        if self.path_without_protocol.rstrip(
+            "/"
+        ) == dst_path.path_without_protocol.rstrip("/"):
+            raise SameFileError(
+                "%r and %r are the same file"
+                % (self.path_with_protocol, dst_path.path_with_protocol)
+            )
         src_stat = self.stat()
         if src_stat.is_dir():
             if not recursive:
@@ -393,27 +397,24 @@ class HdfsPath(URIPath):
             for filename in self.iterdir():
                 filename.rename(
                     dst_path.joinpath(filename.relative_to(self.path_with_protocol)),
-                    overwrite=overwrite,
                     recursive=recursive,
                 )
         else:
-            if overwrite:
-                dst_path.remove(missing_ok=True)
-            if overwrite or not dst_path.exists():
-                with raise_hdfs_error(self.path_with_protocol):
-                    self._client.rename(
-                        self.path_without_protocol, dst_path.path_without_protocol
-                    )
+            dst_path.remove(missing_ok=True)
+            with raise_hdfs_error(self.path_with_protocol):
+                self._client.rename(
+                    self.path_without_protocol, dst_path.path_without_protocol
+                )
         self.remove(missing_ok=True)
         return dst_path
 
-    def move(self, dst_path: PathLike, overwrite: bool = True) -> None:
+    def move(self, dst_path: PathLike) -> None:
         """
         Move file/directory path from src_path to dst_path
 
         :param dst_path: Given destination path
         """
-        self.rename(dst_path=dst_path, overwrite=overwrite, recursive=True)
+        self.rename(dst_path=dst_path, recursive=True)
 
     def remove(self, missing_ok: bool = False) -> None:
         """

--- a/megfile/pathlike.py
+++ b/megfile/pathlike.py
@@ -729,26 +729,23 @@ class BasePath:
     def rename(
         self: Self,
         dst_path: "PathLike",
-        overwrite: bool = True,
         recursive: bool = True,
     ) -> Self:
         """
         rename file
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         :param recursive: whether or not rename directory recursively
         """
         raise NotImplementedError(f"'rename' is unsupported on '{type(self)}'")
 
-    def replace(self: Self, dst_path: "PathLike", overwrite: bool = True) -> Self:
+    def replace(self: Self, dst_path: "PathLike") -> Self:
         """
         move file
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         """
-        return self.rename(dst_path=dst_path, overwrite=overwrite)
+        return self.rename(dst_path=dst_path)
 
     def md5(self, recalculate: bool = False, followlinks: bool = False) -> str:
         raise NotImplementedError(f"'md5' is unsupported on '{type(self)}'")

--- a/megfile/s3_path.py
+++ b/megfile/s3_path.py
@@ -2069,19 +2069,16 @@ class S3Path(URIPath):
         if self.exists():
             raise S3FileExistsError("File exists: %r" % self.path_with_protocol)
 
-    def move(self, dst_url: PathLike, overwrite: bool = True) -> None:
+    def move(self, dst_url: PathLike) -> None:
         """
         Move file/directory path from src_url to dst_url
 
         :param dst_url: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         """
         for src_file_path, dst_file_path in _s3_scan_pairs(
             self.path_with_protocol, dst_url
         ):
-            S3Path(src_file_path).rename(
-                dst_file_path, overwrite=overwrite, recursive=False
-            )
+            S3Path(src_file_path).rename(dst_file_path, recursive=False)
 
     def remove(self, missing_ok: bool = False) -> None:
         """
@@ -2168,27 +2165,33 @@ class S3Path(URIPath):
                     "No such file or directory: %r" % self.path_with_protocol
                 )
 
-    def rename(
-        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
-    ) -> "S3Path":
+    def rename(self, dst_path: PathLike, recursive: bool = True) -> "S3Path":
         """
         Move s3 file path from src_url to dst_url
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         :param recursive: whether or not rename directory recursively
         """
+        dst_path = self.from_path(dst_path)
+        src_bucket, src_key = parse_s3_url(self.path_with_protocol)
+        dst_bucket, dst_key = parse_s3_url(dst_path.path_with_protocol)
+        if src_bucket == dst_bucket and src_key.rstrip("/") == dst_key.rstrip("/"):
+            raise SameFileError(
+                "%r and %r are the same file"
+                % (self.path_with_protocol, dst_path.path_with_protocol)
+            )
+
         if not recursive:
-            self.copy(dst_path, overwrite=overwrite)
+            self.copy(dst_path)
             self.unlink()
-            return self.from_path(dst_path)
+            return dst_path
 
         if self.is_file():
-            self.copy(dst_path, overwrite=overwrite)
+            self.copy(dst_path)
         else:
-            self.sync(dst_path, overwrite=overwrite)
+            self.sync(dst_path)
         self.remove(missing_ok=True)
-        return self.from_path(dst_path)
+        return dst_path
 
     def scan(self, missing_ok: bool = True, followlinks: bool = False) -> Iterator[str]:
         """

--- a/megfile/sftp2_path.py
+++ b/megfile/sftp2_path.py
@@ -636,9 +636,7 @@ class Sftp2Path(URIPath):
     def _is_same_protocol(self, path):
         return is_sftp2(path)
 
-    def rename(
-        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
-    ) -> "Sftp2Path":
+    def rename(self, dst_path: PathLike, recursive: bool = True) -> "Sftp2Path":
         """Rename file on sftp2"""
         if not self._is_same_protocol(dst_path):
             raise OSError(f"Not a {self.protocol} path: {dst_path!r}")
@@ -649,35 +647,32 @@ class Sftp2Path(URIPath):
             raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if self._is_same_backend(dst_path):
-            if overwrite:
-                dst_path.remove(missing_ok=True)
-                self._client.rename(self._remote_path, dst_path._remote_path)
-            else:
-                self.sync(dst_path, overwrite=overwrite)
-                self.remove(missing_ok=True)
+            if self._remote_path.rstrip("/") == dst_path._remote_path.rstrip("/"):
+                raise SameFileError(
+                    "%r and %r are the same file"
+                    % (self.path_with_protocol, dst_path.path_with_protocol)
+                )
+            dst_path.remove(missing_ok=True)
+            self._client.rename(self._remote_path, dst_path._remote_path)
         else:
             if src_stat.is_dir():
                 for file_entry in self.scandir():
                     self.from_path(file_entry.path).rename(
                         dst_path.joinpath(file_entry.name),
-                        overwrite=overwrite,
                         recursive=recursive,
                     )
                 self._client.rmdir(self._remote_path)
             else:
-                if overwrite or not dst_path.exists():
-                    with self.open("rb") as fsrc:
-                        with dst_path.open("wb") as fdst:
-                            copyfileobj(fsrc, fdst)
+                self.copy(dst_path)
                 self.unlink()
 
         dst_path.utime(src_stat.st_atime, src_stat.st_mtime)
         dst_path.chmod(src_stat.st_mode)
         return dst_path
 
-    def replace(self, dst_path: PathLike, overwrite: bool = True) -> "Sftp2Path":
+    def replace(self, dst_path: PathLike) -> "Sftp2Path":
         """Move file on sftp2"""
-        return self.rename(dst_path=dst_path, overwrite=overwrite)
+        return self.rename(dst_path=dst_path)
 
     def remove(self, missing_ok: bool = False) -> None:
         """Remove the file or directory on sftp2"""

--- a/megfile/sftp_path.py
+++ b/megfile/sftp_path.py
@@ -921,14 +921,11 @@ class SftpPath(URIPath):
     def _is_same_protocol(self, path):
         return is_sftp(path)
 
-    def rename(
-        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
-    ) -> "SftpPath":
+    def rename(self, dst_path: PathLike, recursive: bool = True) -> "SftpPath":
         """
         rename file on sftp
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         :param recursive: whether or not rename directory recursively
         """
         if not self._is_same_protocol(dst_path):
@@ -941,40 +938,36 @@ class SftpPath(URIPath):
             raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if self._is_same_backend(dst_path):
-            if overwrite:
-                dst_path.remove(missing_ok=True)
-                self._client.rename(self._real_path, dst_path._real_path)
-            else:
-                self.sync(dst_path, overwrite=overwrite)
-                self.remove(missing_ok=True)
+            if self._real_path.rstrip("/") == dst_path._real_path.rstrip("/"):
+                raise SameFileError(
+                    "%r and %r are the same file"
+                    % (self.path_with_protocol, dst_path.path_with_protocol)
+                )
+            dst_path.remove(missing_ok=True)
+            self._client.rename(self._real_path, dst_path._real_path)
         else:
             if src_stat.is_dir():
                 for file_entry in self.scandir():
                     self.from_path(file_entry.path).rename(
                         dst_path.joinpath(file_entry.name),
-                        overwrite=overwrite,
                         recursive=recursive,
                     )
                 self._client.rmdir(self._real_path)
             else:
-                if overwrite or not dst_path.exists():
-                    with self.open("rb") as fsrc:
-                        with dst_path.open("wb") as fdst:
-                            copyfileobj(fsrc, fdst)
+                self.copy(dst_path)
                 self.unlink()
 
         dst_path.utime(src_stat.st_atime, src_stat.st_mtime)
         dst_path.chmod(src_stat.st_mode)
         return dst_path
 
-    def replace(self, dst_path: PathLike, overwrite: bool = True) -> "SftpPath":
+    def replace(self, dst_path: PathLike) -> "SftpPath":
         """
         move file on sftp
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         """
-        return self.rename(dst_path=dst_path, overwrite=overwrite)
+        return self.rename(dst_path=dst_path)
 
     def remove(self, missing_ok: bool = False) -> None:
         """

--- a/megfile/smart.py
+++ b/megfile/smart.py
@@ -625,41 +625,37 @@ def smart_remove(path: PathLike, missing_ok: bool = False) -> None:
     SmartPath(path).remove(missing_ok=missing_ok)
 
 
-def smart_rename(
-    src_path: PathLike, dst_path: PathLike, overwrite: bool = True
-) -> None:
+def smart_rename(src_path: PathLike, dst_path: PathLike) -> None:
     """
     Move file on s3 or fs. `s3://` or `s3://bucket` is not allowed to move
 
     :param src_path: Given source path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     """
     src_protocol = SmartPath._extract_protocol(src_path)
     dst_protocol = SmartPath._extract_protocol(dst_path)
     if src_protocol == dst_protocol:
-        SmartPath(src_path).rename(dst_path, overwrite=overwrite, recursive=False)
+        SmartPath(src_path).rename(dst_path, recursive=False)
         return
     if smart_isdir(src_path):
         raise IsADirectoryError("%r is a directory" % src_path)
-    smart_copy(src_path, dst_path, overwrite=overwrite)
+    smart_copy(src_path, dst_path)
     smart_unlink(src_path)
 
 
-def smart_move(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) -> None:
+def smart_move(src_path: PathLike, dst_path: PathLike) -> None:
     """
     Move file/directory on s3 or fs. `s3://` or `s3://bucket` is not allowed to move
 
     :param src_path: Given source path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     """
     src_protocol = SmartPath._extract_protocol(src_path)
     dst_protocol = SmartPath._extract_protocol(dst_path)
     if src_protocol == dst_protocol:
-        SmartPath(src_path).rename(dst_path, overwrite=overwrite, recursive=True)
+        SmartPath(src_path).rename(dst_path, recursive=True)
         return
-    smart_sync(src_path, dst_path, followlinks=True, overwrite=overwrite)
+    smart_sync(src_path, dst_path, followlinks=True)
     smart_remove(src_path)
 
 

--- a/megfile/webdav_path.py
+++ b/megfile/webdav_path.py
@@ -579,14 +579,11 @@ class WebdavPath(URIPath):
         """Check if path is a WebDAV path"""
         return is_webdav(path)
 
-    def rename(
-        self, dst_path: PathLike, overwrite: bool = True, recursive: bool = True
-    ) -> "WebdavPath":
+    def rename(self, dst_path: PathLike, recursive: bool = True) -> "WebdavPath":
         """
         Rename file on WebDAV
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         :param recursive: whether or not rename directory recursively
         """
         if not self._is_same_protocol(dst_path):
@@ -598,37 +595,33 @@ class WebdavPath(URIPath):
             raise IsADirectoryError("Is a directory: %r" % self.path_with_protocol)
 
         if self._is_same_backend(dst_path):
-            if overwrite:
-                dst_path.remove(missing_ok=True)
-            self._client.move(
-                self._remote_path, dst_path._remote_path, overwrite=overwrite
-            )
+            if self._remote_path.rstrip("/") == dst_path._remote_path.rstrip("/"):
+                raise SameFileError(
+                    "%r and %r are the same file"
+                    % (self.path_with_protocol, dst_path.path_with_protocol)
+                )
+            self._client.move(self._remote_path, dst_path._remote_path, overwrite=True)
         else:
             if src_stat.is_dir():
                 for file_entry in self.scandir():
                     self.from_path(file_entry.path).rename(
                         dst_path.joinpath(file_entry.name),
-                        overwrite=overwrite,
                         recursive=recursive,
                     )
                 self.rmdir()
             else:
-                if overwrite or not dst_path.exists():
-                    with self.open("rb") as fsrc:
-                        with dst_path.open("wb") as fdst:
-                            copyfileobj(fsrc, fdst)
+                self.copy(dst_path)
                 self.unlink()
 
         return dst_path
 
-    def replace(self, dst_path: PathLike, overwrite: bool = True) -> "WebdavPath":
+    def replace(self, dst_path: PathLike) -> "WebdavPath":
         """
         Move file on WebDAV
 
         :param dst_path: Given destination path
-        :param overwrite: whether or not overwrite file when exists
         """
-        return self.rename(dst_path=dst_path, overwrite=overwrite)
+        return self.rename(dst_path=dst_path)
 
     def remove(self, missing_ok: bool = False) -> None:
         """

--- a/tests/compat/fs.py
+++ b/tests/compat/fs.py
@@ -564,7 +564,6 @@ def fs_lstat(path: PathLike) -> StatResult:
 def fs_rename(
     src_path: PathLike,
     dst_path: PathLike,
-    overwrite: bool = True,
     recursive: bool = True,
 ) -> None:
     """
@@ -572,21 +571,19 @@ def fs_rename(
 
     :param src_path: Given path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     :param recursive: whether or not rename directory recursively
     """
-    FSPath(src_path).rename(dst_path, overwrite=overwrite, recursive=recursive)
+    FSPath(src_path).rename(dst_path, recursive=recursive)
 
 
-def fs_move(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) -> None:
+def fs_move(src_path: PathLike, dst_path: PathLike) -> None:
     """
     rename file on fs
 
     :param src_path: Given path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     """
-    return fs_rename(src_path, dst_path, overwrite=overwrite)
+    return fs_rename(src_path, dst_path)
 
 
 def fs_open(path: PathLike, mode: str = "r", **kwargs) -> IO:

--- a/tests/compat/hdfs.py
+++ b/tests/compat/hdfs.py
@@ -147,14 +147,14 @@ def hdfs_load_from(path: PathLike) -> BinaryIO:
     return HdfsPath(path).load()
 
 
-def hdfs_move(src_path: PathLike, dst_path: PathLike, overwrite: bool = True) -> None:
+def hdfs_move(src_path: PathLike, dst_path: PathLike) -> None:
     """
     Move file/directory path from src_path to dst_path
 
     :param src_path: Given path
     :param dst_path: Given destination path
     """
-    return HdfsPath(src_path).move(dst_path, overwrite=overwrite)
+    return HdfsPath(src_path).move(dst_path)
 
 
 def hdfs_remove(path: PathLike, missing_ok: bool = False) -> None:

--- a/tests/compat/s3.py
+++ b/tests/compat/s3.py
@@ -190,15 +190,14 @@ def s3_hasbucket(path: PathLike) -> bool:
     return S3Path(path).hasbucket()
 
 
-def s3_move(src_url: PathLike, dst_url: PathLike, overwrite: bool = True) -> None:
+def s3_move(src_url: PathLike, dst_url: PathLike) -> None:
     """
     Move file/directory path from src_url to dst_url
 
     :param src_url: Given path
     :param dst_url: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     """
-    return S3Path(src_url).move(dst_url, overwrite=overwrite)
+    return S3Path(src_url).move(dst_url)
 
 
 def s3_remove(path: PathLike, missing_ok: bool = False) -> None:
@@ -417,17 +416,14 @@ def s3_readlink(path) -> str:
     return S3Path(path).readlink().path_with_protocol
 
 
-def s3_rename(
-    src_url: PathLike, dst_url: PathLike, overwrite: bool = True, recursive: bool = True
-) -> None:
+def s3_rename(src_url: PathLike, dst_url: PathLike, recursive: bool = True) -> None:
     """
     Move s3 file path from src_url to dst_url
 
     :param dst_url: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     :param recursive: whether or not rename directory recursively
     """
-    S3Path(src_url).rename(dst_url, overwrite=overwrite, recursive=recursive)
+    S3Path(src_url).rename(dst_url, recursive=recursive)
 
 
 def s3_glob(

--- a/tests/compat/sftp.py
+++ b/tests/compat/sftp.py
@@ -343,7 +343,6 @@ def sftp_realpath(path: PathLike) -> str:
 def sftp_rename(
     src_path: PathLike,
     dst_path: PathLike,
-    overwrite: bool = True,
     recursive: bool = True,
 ) -> "SftpPath":
     """
@@ -351,23 +350,19 @@ def sftp_rename(
 
     :param src_path: Given path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     :param recursive: whether or not rename directory recursively
     """
-    return SftpPath(src_path).rename(dst_path, overwrite=overwrite, recursive=recursive)
+    return SftpPath(src_path).rename(dst_path, recursive=recursive)
 
 
-def sftp_move(
-    src_path: PathLike, dst_path: PathLike, overwrite: bool = True
-) -> "SftpPath":
+def sftp_move(src_path: PathLike, dst_path: PathLike) -> "SftpPath":
     """
     move file on sftp
 
     :param src_path: Given path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     """
-    return SftpPath(src_path).replace(dst_path, overwrite=overwrite)
+    return SftpPath(src_path).replace(dst_path)
 
 
 def sftp_remove(path: PathLike, missing_ok: bool = False) -> None:

--- a/tests/compat/sftp2.py
+++ b/tests/compat/sftp2.py
@@ -494,7 +494,6 @@ def sftp2_realpath(path: PathLike) -> str:
 def sftp2_rename(
     src_path: PathLike,
     dst_path: PathLike,
-    overwrite: bool = True,
     recursive: bool = True,
 ) -> "Sftp2Path":
     """
@@ -502,25 +501,19 @@ def sftp2_rename(
 
     :param src_path: Given path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     :param recursive: whether or not rename directory recursively
     """
-    return Sftp2Path(src_path).rename(
-        dst_path, overwrite=overwrite, recursive=recursive
-    )
+    return Sftp2Path(src_path).rename(dst_path, recursive=recursive)
 
 
-def sftp2_move(
-    src_path: PathLike, dst_path: PathLike, overwrite: bool = True
-) -> "Sftp2Path":
+def sftp2_move(src_path: PathLike, dst_path: PathLike) -> "Sftp2Path":
     """
     move file on sftp2
 
     :param src_path: Given path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     """
-    return Sftp2Path(src_path).replace(dst_path, overwrite=overwrite)
+    return Sftp2Path(src_path).replace(dst_path)
 
 
 def sftp2_remove(path: PathLike, missing_ok: bool = False) -> None:

--- a/tests/compat/webdav.py
+++ b/tests/compat/webdav.py
@@ -339,7 +339,6 @@ def webdav_realpath(path: PathLike) -> str:
 def webdav_rename(
     src_path: PathLike,
     dst_path: PathLike,
-    overwrite: bool = True,
     recursive: bool = True,
 ) -> "WebdavPath":
     """
@@ -347,25 +346,19 @@ def webdav_rename(
 
     :param src_path: Given path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     :param recursive: whether or not rename directory recursively
     """
-    return WebdavPath(src_path).rename(
-        dst_path, overwrite=overwrite, recursive=recursive
-    )
+    return WebdavPath(src_path).rename(dst_path, recursive=recursive)
 
 
-def webdav_move(
-    src_path: PathLike, dst_path: PathLike, overwrite: bool = True
-) -> "WebdavPath":
+def webdav_move(src_path: PathLike, dst_path: PathLike) -> "WebdavPath":
     """
     Move file on WebDAV
 
     :param src_path: Given path
     :param dst_path: Given destination path
-    :param overwrite: whether or not overwrite file when exists
     """
-    return WebdavPath(src_path).replace(dst_path, overwrite=overwrite)
+    return WebdavPath(src_path).replace(dst_path)
 
 
 def webdav_remove(path: PathLike, missing_ok: bool = False) -> None:

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1063,16 +1063,10 @@ def test_fs_rename(filesystem):
 
     with open(dst, "w") as f:
         f.write("test1")
-    fs.fs_rename(src, dst, overwrite=False)
-    with open(dst, "r") as f:
-        assert f.read() == "test1"
-
-    with open(src, "w") as f:
-        f.write("test")
-
-    fs.fs_rename(src, dst, overwrite=True)
+    fs.fs_rename(src, dst)
     with open(dst, "r") as f:
         assert f.read() == "test"
+    assert not os.path.exists(src)
 
 
 def test_fs_rename_file_in_diff_dir(filesystem):
@@ -1086,6 +1080,23 @@ def test_fs_rename_file_in_diff_dir(filesystem):
     fs.fs_rename(src, dst)
     assert os.path.exists(dst)
     assert not os.path.exists(src)
+
+
+def test_fs_rename_failure_keeps_source(filesystem):
+    src = "file"
+    dst_parent = "dst_parent"
+    dst = os.path.join(dst_parent, "file")
+    with open(src, "w") as f:
+        f.write("test")
+    with open(dst_parent, "w") as f:
+        f.write("not a directory")
+
+    with pytest.raises(FileExistsError):
+        fs.fs_rename(src, dst)
+
+    assert os.path.exists(src)
+    with open(src, "r") as f:
+        assert f.read() == "test"
 
 
 def test_fs_rename_dir():
@@ -1158,22 +1169,7 @@ def test_fs_move_dir():
         with open(os.path.join(tmpdir, "src_copy/src_file"), "w") as f:
             f.write("test")
 
-        fs.fs_move(
-            os.path.join(tmpdir, "src"),
-            os.path.join(tmpdir, "src_copy"),
-            overwrite=False,
-        )
-        with open(os.path.join(tmpdir, "src_copy/src_file"), "r") as f:
-            assert f.read() == "test"
-
-        os.mkdir(os.path.join(tmpdir, "src"))
-        with open(os.path.join(tmpdir, "src/src_file"), "w") as f:
-            f.write("")
-        fs.fs_move(
-            os.path.join(tmpdir, "src"),
-            os.path.join(tmpdir, "src_copy"),
-            overwrite=True,
-        )
+        fs.fs_move(os.path.join(tmpdir, "src"), os.path.join(tmpdir, "src_copy"))
         with open(os.path.join(tmpdir, "src_copy/src_file"), "r") as f:
             assert f.read() == ""
 

--- a/tests/test_fs_path.py
+++ b/tests/test_fs_path.py
@@ -49,7 +49,7 @@ def test_rename(fs):
         f.write("test")
 
     os.makedirs("test1/dir1", exist_ok=True)
-    FSPath("test").rename("test1", overwrite=False)
+    FSPath("test").rename("test1")
     assert os.path.exists("test1")
     assert not os.path.exists("test")
     with open("test1/dir1/file", "r") as f:
@@ -58,12 +58,12 @@ def test_rename(fs):
     os.makedirs("test2", exist_ok=True)
     with open("test2/file", "w") as f:
         f.write("test1")
-    FSPath("test1/file").rename("test2/file", overwrite=False)
+    FSPath("test1/file").rename("test2/file")
     assert os.path.exists("test2/file")
     assert not os.path.exists("test1/file")
 
     with open("test2/file", "r") as f:
-        assert f.read() == "test1"
+        assert f.read() == "test"
 
 
 def test_copy_symlink(fs):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1175,18 +1175,6 @@ def test_s3_move(truncating_client):
     s3.s3_move(
         "s3://bucketA/folderAA/folderAAA1",
         "s3://bucketA/folderAA/folderAAA2",
-        overwrite=False,
-    )
-    assert s3.s3_exists("s3://bucketA/folderAA/folderAAA1") is False
-    with s3.s3_open("s3://bucketA/folderAA/folderAAA2/fileAAAA", "r") as f:
-        assert f.read() == "fileAAAA"
-    assert s3.s3_exists("s3://bucketA/folderAA/folderAAA1") is False
-
-    smart.smart_touch("s3://bucketA/folderAA/folderAAA1/fileAAAA")
-    s3.s3_move(
-        "s3://bucketA/folderAA/folderAAA1",
-        "s3://bucketA/folderAA/folderAAA2",
-        overwrite=True,
     )
     assert s3.s3_exists("s3://bucketA/folderAA/folderAAA1") is False
     with s3.s3_open("s3://bucketA/folderAA/folderAAA2/fileAAAA", "r") as f:
@@ -1232,6 +1220,11 @@ def test_s3_sync(truncating_client, mocker):
 
 
 def test_s3_rename(truncating_client):
+    with pytest.raises(SameFileError):
+        s3.s3_rename("s3://bucketA/folderAB", "s3://bucketA/folderAB")
+    assert s3.s3_exists("s3://bucketA/folderAB/fileAB") is True
+    assert s3.s3_exists("s3://bucketA/folderAB/fileAC") is True
+
     s3.s3_rename(
         "s3://bucketA/folderAA/folderAAA/fileAAAA",
         "s3://bucketA/folderAA/folderAAA/fileAAAA1",
@@ -1251,19 +1244,6 @@ def test_s3_rename(truncating_client):
     s3.s3_rename(
         "s3://bucketA/folderAA/folderAAA/fileAAAA2",
         "s3://bucketA/folderAA/folderAAA/fileAAAA1",
-        overwrite=False,
-    )
-    with s3.s3_open("s3://bucketA/folderAA/folderAAA/fileAAAA1", "r") as f:
-        assert f.read() == "fileAAAA"
-    assert s3.s3_exists("s3://bucketA/folderAA/folderAAA/fileAAAA2") is False
-
-    with s3.s3_open("s3://bucketA/folderAA/folderAAA/fileAAAA2", "w") as f:
-        f.write("fileAAAA2")
-
-    s3.s3_rename(
-        "s3://bucketA/folderAA/folderAAA/fileAAAA2",
-        "s3://bucketA/folderAA/folderAAA/fileAAAA1",
-        overwrite=True,
     )
     with s3.s3_open("s3://bucketA/folderAA/folderAAA/fileAAAA1", "r") as f:
         assert f.read() == "fileAAAA2"

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -467,6 +467,10 @@ def test_sftp_rename(sftp_mocker):
     with sftp.sftp_open("sftp://username@host//A/test", "w") as f:
         f.write("test")
 
+    with pytest.raises(SameFileError):
+        sftp.sftp_rename("sftp://username@host//A/test", "sftp://username@host//A/test")
+    assert sftp.sftp_exists("sftp://username@host//A/test") is True
+
     sftp.sftp_rename("sftp://username@host//A/test", "sftp://username@host//A/test2")
     assert sftp.sftp_exists("sftp://username@host//A/test") is False
     assert sftp.sftp_exists("sftp://username@host//A/test2") is True
@@ -506,20 +510,7 @@ def test_sftp_move(sftp_mocker):
     sftp.sftp_makedirs("sftp://username@host//A3")
     with sftp.sftp_open("sftp://username@host//A3/test2", "w") as f:
         f.write("test3")
-    sftp.sftp_move(
-        "sftp://username@host//A3", "sftp://username@host//A2", overwrite=False
-    )
-    assert sftp.sftp_exists("sftp://username@host//A3/test2") is False
-    assert sftp.sftp_exists("sftp://username@host//A2/test2") is True
-    with sftp.sftp_open("sftp://username@host//A2/test2", "r") as f:
-        assert f.read() == "test"
-
-    sftp.sftp_makedirs("sftp://username@host//A3")
-    with sftp.sftp_open("sftp://username@host//A3/test2", "w") as f:
-        f.write("test3")
-    sftp.sftp_move(
-        "sftp://username@host//A3", "sftp://username@host//A2", overwrite=True
-    )
+    sftp.sftp_move("sftp://username@host//A3", "sftp://username@host//A2")
     assert sftp.sftp_exists("sftp://username@host//A3/test2") is False
     assert sftp.sftp_exists("sftp://username@host//A2/test2") is True
     with sftp.sftp_open("sftp://username@host//A2/test2", "r") as f:

--- a/tests/test_sftp2.py
+++ b/tests/test_sftp2.py
@@ -7,6 +7,7 @@ from typing import List
 
 import pytest
 
+from megfile.errors import SameFileError
 from tests.compat import sftp2
 
 
@@ -454,6 +455,12 @@ def test_sftp2_rename(sftp2_mocker):
     with sftp2.sftp2_open("sftp2://username@host/A/test", "w") as f:
         f.write("test")
 
+    with pytest.raises(SameFileError):
+        sftp2.sftp2_rename(
+            "sftp2://username@host/A/test", "sftp2://username@host/A/test"
+        )
+    assert sftp2.sftp2_exists("sftp2://username@host/A/test") is True
+
     sftp2.sftp2_rename("sftp2://username@host/A/test", "sftp2://username@host/A/test2")
     assert sftp2.sftp2_exists("sftp2://username@host/A/test") is False
     assert sftp2.sftp2_exists("sftp2://username@host/A/test2") is True
@@ -738,9 +745,7 @@ def test_sftp2_rename_different_backend(sftp2_mocker):
 
     # When renaming between different backends, it should copy and delete
     # This is simulated by the mock, but tests the code path
-    sftp2.sftp2_rename(
-        "sftp2://username@host/A/test", "sftp2://username@host/B/test", overwrite=True
-    )
+    sftp2.sftp2_rename("sftp2://username@host/A/test", "sftp2://username@host/B/test")
     assert sftp2.sftp2_exists("sftp2://username@host/B/test") is True
     assert sftp2.sftp2_exists("sftp2://username@host/A/test") is False
 
@@ -876,7 +881,7 @@ def test_sftp2_rename_cross_backend(sftp2_mocker):
 
     # Rename file to different location (same backend)
     Sftp2Path("sftp2://username@host/src/file.txt").rename(
-        "sftp2://username@host/dst/file.txt", overwrite=True
+        "sftp2://username@host/dst/file.txt"
     )
 
     assert sftp2.sftp2_exists("sftp2://username@host/dst/file.txt") is True

--- a/tests/test_smart.py
+++ b/tests/test_smart.py
@@ -495,7 +495,7 @@ def test_smart_move(mocker):
     funcA.return_value = None
     res = smart.smart_move("s3://bucket/a", "s3://bucket/b")
     assert res is None
-    funcA.assert_called_once_with("s3://bucket/b", overwrite=True, recursive=True)
+    funcA.assert_called_once_with("s3://bucket/b", recursive=True)
 
     res = smart.smart_move("/bucket/a", "/bucket/b")
     assert res is None
@@ -505,7 +505,7 @@ def test_smart_move(mocker):
     func_smart_remove = mocker.patch("megfile.smart.smart_remove")
     smart.smart_move("/bucket/a", "s3://bucket/b")
     func_smart_sync.assert_called_once_with(
-        "/bucket/a", "s3://bucket/b", followlinks=True, overwrite=True
+        "/bucket/a", "s3://bucket/b", followlinks=True
     )
     func_smart_remove.assert_called_once_with("/bucket/a")
 
@@ -516,7 +516,7 @@ def test_smart_rename(funcA, mocker):
     funcA.return_value = None
     res = smart.smart_rename("s3://bucket/a", "s3://bucket/b")
     assert res is None
-    funcA.assert_called_once_with("s3://bucket/b", overwrite=True, recursive=False)
+    funcA.assert_called_once_with("s3://bucket/b", recursive=False)
     smart_isdir.assert_not_called()
 
 
@@ -547,6 +547,30 @@ def test_smart_rename_fs(s3_empty_client, filesystem):
     smart.smart_rename("tmp_rename/src_copy", "s3://bucket/src_copy")
     assert smart.smart_exists("s3://bucket/src_copy")
     assert not smart.smart_exists("tmp_rename/src_copy")
+
+
+def test_smart_rename_cross_protocol_failure_keeps_source(mocker):
+    smart_isdir = mocker.patch("megfile.smart.smart_isdir", return_value=False)
+    smart_copy = mocker.patch("megfile.smart.smart_copy", side_effect=OSError)
+    smart_unlink = mocker.patch("megfile.smart.smart_unlink")
+
+    with pytest.raises(OSError):
+        smart.smart_rename("/bucket/a", "s3://bucket/a")
+
+    smart_isdir.assert_called_once_with("/bucket/a")
+    smart_copy.assert_called_once_with("/bucket/a", "s3://bucket/a")
+    smart_unlink.assert_not_called()
+
+
+def test_smart_move_cross_protocol_failure_keeps_source(mocker):
+    smart_sync = mocker.patch("megfile.smart.smart_sync", side_effect=OSError)
+    smart_remove = mocker.patch("megfile.smart.smart_remove")
+
+    with pytest.raises(OSError):
+        smart.smart_move("/bucket/a", "s3://bucket/a")
+
+    smart_sync.assert_called_once_with("/bucket/a", "s3://bucket/a", followlinks=True)
+    smart_remove.assert_not_called()
 
 
 @patch.object(SmartPath, "unlink")

--- a/tests/test_webdav_path.py
+++ b/tests/test_webdav_path.py
@@ -359,6 +359,10 @@ def test_rename_same_backend(webdav_mocker):
     with webdav.webdav_open("webdav://host/A/file.txt", "w") as f:
         f.write("test content")
 
+    with pytest.raises(SameFileError):
+        WebdavPath("webdav://host/A/file.txt").rename("webdav://host/A/file.txt")
+    assert WebdavPath("webdav://host/A/file.txt").exists()
+
     # Rename within same backend should use WebDAV's native move
     WebdavPath("webdav://host/A/file.txt").rename("webdav://host/B/file.txt")
 


### PR DESCRIPTION
## Summary

Remove the `overwrite` option from the move-family APIs while keeping the existing default overwrite behavior. The copy family keeps its `overwrite` option and CLI `cp/sync --skip` support.

## Changes

- Remove `overwrite` from `rename`, `move`, `replace`, `smart_rename`, `smart_move`, and the compat move helpers.
- Remove CLI `mv --skip`; `mv` now follows the default overwrite behavior.
- Keep `overwrite` on copy/sync/upload/download APIs.
- Reuse protocol `copy()` in SFTP/SFTP2/WebDAV cross-backend file rename before unlinking the source.
- Add same-source/destination guards for S3/HDFS/SFTP/SFTP2/WebDAV rename paths that otherwise might delete the source while preparing overwrite behavior.

## Failure Semantics

- Cross-protocol `smart_rename` and `smart_move` only delete the source after copy/sync succeeds.
- Local rename failure keeps the source file.
- Same-source/destination rename now raises `SameFileError` before destructive destination cleanup in the touched protocols.

## Testing

- `pytest tests/test_sftp.py::test_sftp_rename tests/test_sftp2.py::test_sftp2_rename tests/test_s3.py::test_s3_rename tests/test_webdav_path.py::test_rename_same_backend tests/test_smart.py::test_smart_rename_cross_protocol_failure_keeps_source tests/test_smart.py::test_smart_move_cross_protocol_failure_keeps_source -q`
- `pytest tests/test_fs.py tests/test_fs_path.py tests/test_smart.py tests/test_s3.py tests/test_sftp.py tests/test_sftp2.py tests/test_webdav.py tests/test_webdav_path.py -q -k 'not test_provide_connect_info'`
- `make style_check`

`test_provide_connect_info` is excluded locally because the devbox megfile config injects WebDAV credentials into that test.
