### PR TITLE
feat: add config error base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+- feat
+    - Add `ConfigError` as a common base class for configuration errors
+
 ## 5.0.14 - 2026.06.02
 - feat
     - Add `recursive` option to `Path.rename()` and protocol rename APIs

--- a/megfile/errors.py
+++ b/megfile/errors.py
@@ -26,6 +26,7 @@ __all__ = [
     "S3NotADirectoryError",
     "S3IsADirectoryError",
     "S3PermissionError",
+    "ConfigError",
     "S3ConfigError",
     "UnknownError",
     "UnsupportedError",
@@ -421,7 +422,13 @@ class S3PermissionError(S3Exception, PermissionError):
     pass
 
 
-class S3ConfigError(S3Exception, EnvironmentError):
+class ConfigError(EnvironmentError):
+    """
+    Base type for configuration errors.
+    """
+
+
+class S3ConfigError(S3Exception, ConfigError):
     """
     Error raised by wrong S3 config, including wrong config file format,
     wrong aws_secret_access_key / aws_access_key_id, and etc.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,6 +8,7 @@ import urllib3.exceptions
 
 from megfile.errors import (
     ClientError,
+    ConfigError,
     HTTPError,
     HttpException,
     HttpFileNotFoundError,
@@ -84,6 +85,12 @@ def test_megfile_unsupported_error_pickle():
     error = UnsupportedError("operation", "path")
     error = pickle.loads(pickle.dumps(error))
     assert "path" in str(error)
+
+
+def test_s3_config_error_inherits_config_error():
+    error = S3ConfigError("bad config")
+    assert isinstance(error, ConfigError)
+    assert isinstance(error, EnvironmentError)
 
 
 def test_translate_s3_error():


### PR DESCRIPTION
## Summary
- add `ConfigError` as a common base class for configuration errors
- make `S3ConfigError` inherit from `ConfigError` while preserving its `EnvironmentError`/`OSError` behavior
- cover the inheritance contract in `tests/test_errors.py`

## Notes
- This intentionally does not split `NetworkError` out of `UnknownError`; existing unknown-error classification stays unchanged.

## Tests
- `python -m pytest tests/test_errors.py`
