### PR TITLE
feat: support defining aliases via MEGFILE_ALIASES__ environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ You can get the configuration from `~/.config/megfile/aliases.conf`, like:
 protocol = s3+tos
 ```
 
+You can also define aliases with environment variables. `MEGFILE_ALIASES__<NAME>`
+is equivalent to a `NAME = <value>` entry in the `[alias]` section of
+`~/.config/megfile/megfile.conf`, and takes precedence over the config file for
+the same alias name:
+```
+$ export MEGFILE_ALIASES__TOS=s3+tos
+$ export MEGFILE_ALIASES__DATASET=s3+prod://bucket/prefix
+```
+
 You can use alias in path, like `tos://bucket/key`, the same as `s3+tos://bucket/key`.
 
 ## Benchmark

--- a/megfile/smart_path.py
+++ b/megfile/smart_path.py
@@ -14,6 +14,28 @@ from .errors import ProtocolExistsError, ProtocolNotFoundError
 from .interfaces import BasePath, PathLike
 
 LEGACY_ALIASES_CONFIG = "~/.config/megfile/aliases.conf"
+ALIASES_ENV_PREFIX = "MEGFILE_ALIASES__"
+
+
+def _load_aliases_from_env() -> Dict[str, str]:
+    """Load alias definitions from environment variables.
+
+    ``MEGFILE_ALIASES__OSS=s3+oss`` is equivalent to the config file entry::
+
+        [alias]
+        oss = s3+oss
+
+    Alias names are lowercased, matching the case-insensitive behavior of ini
+    option names. Environment variables take precedence over the config file
+    for the same alias name.
+    """
+    aliases = {}
+    for key, value in os.environ.items():
+        if key.startswith(ALIASES_ENV_PREFIX):
+            name = key[len(ALIASES_ENV_PREFIX) :]
+            if name:
+                aliases[name.lower()] = value
+    return aliases
 
 
 def _bind_function(name, after_callback=None, before_callback=None):
@@ -63,7 +85,9 @@ def _load_aliases_config() -> Dict[str, Dict[str, str]]:
         parser.read(config_path)
         for section in parser.sections():
             configs[section] = dict(parser.items(section))
-    for name, protocol_or_path in load_megfile_config("alias").items():
+    alias_config = load_megfile_config("alias")
+    alias_config.update(_load_aliases_from_env())
+    for name, protocol_or_path in alias_config.items():
         if "://" in protocol_or_path:
             protocol, prefix = protocol_or_path.split("://", maxsplit=1)
             configs[name] = {"protocol": protocol, "prefix": prefix}

--- a/tests/test_smart_path.py
+++ b/tests/test_smart_path.py
@@ -139,6 +139,34 @@ def test_aliases(fs, sftp_mocker):
         assert str(SmartPath("dev://dir/file")) == "dev://dir/file"
 
 
+def test_aliases_from_env(fs, monkeypatch):
+    # isolate from the real config files on the machine running the tests
+    fs.create_file(os.path.expanduser(CONFIG_PATH), contents="[alias]\n")
+    monkeypatch.setenv("MEGFILE_ALIASES__OSS", "s3+oss")
+    monkeypatch.setenv("MEGFILE_ALIASES__DATASET", "s3+prod://bucket/prefix")
+    aliases = _load_aliases_config()
+    assert aliases["oss"] == {"protocol": "s3+oss"}
+    assert aliases["dataset"] == {"protocol": "s3+prod", "prefix": "bucket/prefix"}
+
+    with patch.object(SmartPath, "_aliases", new_callable=PropertyMock) as mock_aliases:
+        mock_aliases.return_value = aliases
+        assert (
+            SmartPath("oss://bucket/dir/file").pathlike
+            == SmartPath("s3+oss://bucket/dir/file").pathlike
+        )
+        assert str(SmartPath("oss://bucket/dir/file")) == "oss://bucket/dir/file"
+
+
+def test_aliases_from_env_override_config(fs, monkeypatch):
+    fs.create_file(
+        os.path.expanduser(CONFIG_PATH),
+        contents="[alias]\noss = s3+oss",
+    )
+    monkeypatch.setenv("MEGFILE_ALIASES__OSS", "s3+other")
+    aliases = _load_aliases_config()
+    assert aliases["oss"] == {"protocol": "s3+other"}
+
+
 @patch.object(SmartPath, "_create_pathlike")
 def test_init(funcA):
     SmartPath(FS_TEST_ABSOLUTE_PATH)


### PR DESCRIPTION
## What

Aliases can now be defined with environment variables, in addition to `~/.config/megfile/aliases.conf` and the `[alias]` section of `~/.config/megfile/megfile.conf`:

```bash
export MEGFILE_ALIASES__OSS=s3+oss
```

is equivalent to:

```ini
[alias]
oss = s3+oss
```

## Semantics

- All existing alias value forms are supported: `s3+oss` (protocol+profile), `s3+prod://bucket/prefix` (with path prefix), `s3` (bare protocol).
- Alias names are lowercased, matching the case-insensitive behavior of ini option names, so `MEGFILE_ALIASES__S3+OSS=s3+m3` also works.
- Environment variables take precedence over the config file for the same alias name — consistent with the existing convention that environments take precedence over configuration files.

## Tests

- `test_aliases_from_env`: env-defined aliases load correctly (plain and prefixed forms) and resolve via `SmartPath`.
- `test_aliases_from_env_override_config`: env var overrides the same-named config file alias.
- Both tests isolate the real config files via pyfakefs so they don't depend on machine state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)