### PR TITLE
feat: redesign s3 writer block autoscale tiers

### DIFF
--- a/megfile/lib/s3_buffered_writer.py
+++ b/megfile/lib/s3_buffered_writer.py
@@ -42,6 +42,7 @@ class S3BufferedWriter(Writable[bytes]):
     # Multi-upload part size must be between 5 MiB and 5 GiB.
     # There is no minimum size limit on the last part of your multipart upload.
     MIN_BLOCK_SIZE = 8 * 2**20
+    MAX_BLOCK_SIZE = 5 * 2**30
 
     def __init__(
         self,
@@ -115,15 +116,25 @@ class S3BufferedWriter(Writable[bytes]):
     @property
     def _block_size(self) -> int:
         if self._block_autoscale:
-            if self._part_number < 10:
+            # Growth starts at part 1280 (~10GiB at the 8MiB default), so
+            # 8-10GiB streams keep the base block size end to end instead of
+            # collapsing per-file concurrency (max_buffer_size / block_size)
+            # from part 10 (~80MiB). Tiers are x1/x4/x16; capping at x16
+            # keeps peak memory at ~2x block (~256MiB at the 8MiB default)
+            # while raising the autoscale ceiling from ~592GiB to ~980GiB.
+            if self._part_number < 1280:
                 return self._base_block_size
-            elif self._part_number < 100:
-                return min(self._base_block_size * 2, self._max_buffer_size)
-            elif self._part_number < 1000:
-                return min(self._base_block_size * 4, self._max_buffer_size)
-            elif self._part_number < 10000:
-                return min(self._base_block_size * 8, self._max_buffer_size)
-            return min(self._base_block_size * 16, self._max_buffer_size)  # unreachable
+            elif self._part_number < 2560:
+                return min(
+                    self._base_block_size * 4,
+                    self._max_buffer_size,
+                    self.MAX_BLOCK_SIZE,
+                )
+            return min(
+                self._base_block_size * 16,
+                self._max_buffer_size,
+                self.MAX_BLOCK_SIZE,
+            )
         return self._base_block_size
 
     @property

--- a/tests/lib/test_s3_buffered_writer.py
+++ b/tests/lib/test_s3_buffered_writer.py
@@ -235,7 +235,7 @@ def test_s3_buffered_writer_write_multipart_autoscale(client, mocker):
     assert put_object_func.call_count == 0
     create_multipart_upload_func.assert_called_once_with(Bucket=BUCKET, Key=KEY)
 
-    assert upload_part_func.call_count == 16
+    assert upload_part_func.call_count == 21
 
     complete_multipart_upload_func.assert_called_once_with(
         Bucket=BUCKET,
@@ -258,13 +258,19 @@ def test_s3_buffered_writer_autoscale_block_size(client, mocker):
     ) as writer:
         writer._block_autoscale = True
 
-        writer._part_number = 999
+        writer._part_number = 1279
+        assert writer._block_size == 1
+
+        writer._part_number = 1280
         assert writer._block_size == 4
 
-        writer._part_number = 9999
-        assert writer._block_size == 8
+        writer._part_number = 2559
+        assert writer._block_size == 4
 
-        writer._part_number = 10000
+        writer._part_number = 2560
+        assert writer._block_size == 12
+
+        writer._part_number = 9999
         assert writer._block_size == 12
 
         writer._block_autoscale = False


### PR DESCRIPTION
## Problem

`S3BufferedWriter`'s block autoscale starts growing the block size at part 10 (~80MiB written at the 8MiB default). Per-file upload concurrency is `max_buffer_size / block_size`, so for any stream larger than ~80MiB the block grows x2/x4/x8 and concurrency collapses 16 → 8 → 4 → 2 mid-write. On our backend this costs ~44% single-file throughput at 5GiB (324 vs 585 MB/s pinned vs autoscaled, measured with the same defaults). 8-10GiB files pay the full price even though they are nowhere near the 10000-part limit the autoscale exists to avoid.

## Change

Redesign the autoscale tiers so growth is late, steep, and memory-bounded:

| part_number | before | after (8MiB base) |
| --- | --- | --- |
| <1280 | x1 (<10) | **x1** (8MiB, covers 10GiB) |
| <2560 | x2 (<100) | **x4** (32MiB, ~50GiB cumulative) |
| <10000 | x4/x8 (<1000/<10000) | **x16** (128MiB, ~980GiB ceiling) |

- Growth starts at part 1280 (~10GiB at the 8MiB default), so 8-10GiB streams keep the base block size end to end.
- The multiplier caps at x16 (128MiB at the 8MiB default): the writer must buffer a full block before submitting, so peak memory is ~2x block; x16 keeps that at ~256MiB instead of drifting toward GiB-sized blocks.
- Autoscale file-size ceiling rises from ~592GiB to ~980GiB.
- Autoscaled blocks are now also clamped to the 5GiB S3 part-size limit (`MAX_BLOCK_SIZE`), covering the case where `max_buffer_size` is set above 5GiB.

Compatibility: default `block_size`/`max_buffer_size` unchanged; explicit `block_size` still pins; `block_autoscale` still opts out; Cloudflare R2 still disables autoscale. Only the growth curve changes.

## Testing

- Updated `test_s3_buffered_writer_autoscale_block_size` to the new boundaries (1279/1280/2559/2560/9999).
- `test_s3_buffered_writer_write_multipart_autoscale` part count updated 16 → 21 (a 160MiB upload now stays at base block size throughout, which is the point of the change).
- `tests/lib` (160 passed) and `tests/test_s3.py` (103 passed) with moto.
